### PR TITLE
Pr 117 mask instr

### DIFF
--- a/FUNCTIONALITIES.md
+++ b/FUNCTIONALITIES.md
@@ -61,6 +61,7 @@ This file specifies the functionalities of the RISC-V Vector Specification suppo
 ## Vector mask instructions
 
 - Vector mask-register logical instructions: `vmand`, `vmnand`, `vmandnot`, `vmxor`, `vmor`, `vmnor`, `vmornot`, `vmxnor`
+- Vector count population in mask instruction: `vcpop`
 
 ## Vector permutation instructions
 

--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -114,6 +114,7 @@ rv64uv_sc_tests = vadd \
                   vmxor \
                   vmxnor \
                   vcpop \
+                  vpopc_m \
                   vslideup \
                   vslidedown \
                   vslide1up \

--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -113,6 +113,7 @@ rv64uv_sc_tests = vadd \
                   vmornot \
                   vmxor \
                   vmxnor \
+                  vcpop \
                   vslideup \
                   vslidedown \
                   vslide1up \

--- a/apps/riscv-tests/isa/rv64uv/vcpop.c
+++ b/apps/riscv-tests/isa/rv64uv/vcpop.c
@@ -16,7 +16,7 @@ void TEST_CASE1(void) {
   VSET(128, e32, m1);
   volatile uint32_t scalar = 1337;
   volatile uint32_t OUP[] = {0, 0, 0, 0};
-  __asm__ volatile("vpopc.m %[A], v2, v0.t \n"
+  __asm__ volatile("vcpop.m %[A], v2, v0.t \n"
                    "sw %[A], (%1) \n"
                    :
                    : [A] "r"(scalar), "r"(OUP));
@@ -30,7 +30,7 @@ void TEST_CASE2(void) {
   VSET(128, e32, m1);
   volatile uint32_t scalar = 1337;
   volatile uint32_t OUP[] = {0, 0, 0, 0};
-  __asm__ volatile("vpopc.m %[A], v2 \n"
+  __asm__ volatile("vcpop.m %[A], v2 \n"
                    "sw %[A], (%1) \n"
                    :
                    : [A] "r"(scalar), "r"(OUP));
@@ -45,7 +45,7 @@ void TEST_CASE3(void) {
   VSET(48, e8, m1);
   volatile uint32_t scalar = 1337;
   volatile uint32_t OUP[] = {0, 0, 0, 0, 0, 0};
-  __asm__ volatile("vpopc.m %[A], v2, v0.t \n"
+  __asm__ volatile("vcpop.m %[A], v2, v0.t \n"
                    "sw %[A], (%1) \n"
                    :
                    : [A] "r"(scalar), "r"(OUP));
@@ -59,7 +59,7 @@ void TEST_CASE4(void) {
   VSET(48, e8, m1);
   volatile uint32_t scalar = 1337;
   volatile uint32_t OUP[] = {0, 0, 0, 0, 0, 0};
-  __asm__ volatile("vpopc.m %[A], v2 \n"
+  __asm__ volatile("vcpop.m %[A], v2 \n"
                    "sw %[A], (%1) \n"
                    :
                    : [A] "r"(scalar), "r"(OUP));
@@ -73,7 +73,7 @@ void TEST_CASE5(void) {
   VSET(64, e32, m1);
   volatile uint32_t scalar = 1234;
   volatile uint32_t OUP[] = {0, 0};
-  __asm__ volatile("vpopc.m %[A], v2 \n"
+  __asm__ volatile("vcpop.m %[A], v2 \n"
                    "sw %[A], (%1) \n"
                    :
                    : [A] "r"(scalar), "r"(OUP));

--- a/apps/riscv-tests/isa/rv64uv/vcpop.c
+++ b/apps/riscv-tests/isa/rv64uv/vcpop.c
@@ -1,0 +1,93 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
+//         Basile Bougenot <bbougenot@student.ethz.ch>
+
+#include "vector_macros.h"
+
+// masked
+void TEST_CASE1(void) {
+  VSET(4, e32, m1);
+  VLOAD_32(v2, 7, 0, 0, 0);
+  VLOAD_32(v0, 5, 0, 0, 0);
+  // vcpop interprets the vl as bits, not as e32 elements
+  VSET(128, e32, m1);
+  volatile uint32_t scalar = 1337;
+  volatile uint32_t OUP[] = {0, 0, 0, 0};
+  __asm__ volatile("vpopc.m %[A], v2, v0.t \n"
+                   "sw %[A], (%1) \n"
+                   :
+                   : [A] "r"(scalar), "r"(OUP));
+  XCMP(1, OUP[0], 2);
+}
+
+// unmasked
+void TEST_CASE2(void) {
+  VSET(4, e32, m1);
+  VLOAD_32(v2, 9, 7, 5, 3);
+  VSET(128, e32, m1);
+  volatile uint32_t scalar = 1337;
+  volatile uint32_t OUP[] = {0, 0, 0, 0};
+  __asm__ volatile("vpopc.m %[A], v2 \n"
+                   "sw %[A], (%1) \n"
+                   :
+                   : [A] "r"(scalar), "r"(OUP));
+  XCMP(1, OUP[0], 9);
+}
+
+// more elements, smaller elements, masked
+void TEST_CASE3(void) {
+  VSET(6, e8, m1);
+  VLOAD_8(v2, 0xf, 0x0, 0xf, 0x0, 0x3, 0x0);
+  VLOAD_8(v0, 0x1, 0x0, 0x0, 0x0, 0x7, 0x0);
+  VSET(48, e8, m1);
+  volatile uint32_t scalar = 1337;
+  volatile uint32_t OUP[] = {0, 0, 0, 0, 0, 0};
+  __asm__ volatile("vpopc.m %[A], v2, v0.t \n"
+                   "sw %[A], (%1) \n"
+                   :
+                   : [A] "r"(scalar), "r"(OUP));
+  XCMP(1, OUP[0], 3);
+}
+
+// unmasked
+void TEST_CASE4(void) {
+  VSET(6, e8, m1);
+  VLOAD_8(v2, 0xf, 0x0, 0xf, 0x0, 0x3, 0x0);
+  VSET(48, e8, m1);
+  volatile uint32_t scalar = 1337;
+  volatile uint32_t OUP[] = {0, 0, 0, 0, 0, 0};
+  __asm__ volatile("vpopc.m %[A], v2 \n"
+                   "sw %[A], (%1) \n"
+                   :
+                   : [A] "r"(scalar), "r"(OUP));
+  XCMP(1, OUP[0], 10);
+}
+
+// no active elements
+void TEST_CASE5(void) {
+  VSET(2, e32, m1);
+  VLOAD_32(v2, 0, 0);
+  VSET(64, e32, m1);
+  volatile uint32_t scalar = 1234;
+  volatile uint32_t OUP[] = {0, 0};
+  __asm__ volatile("vpopc.m %[A], v2 \n"
+                   "sw %[A], (%1) \n"
+                   :
+                   : [A] "r"(scalar), "r"(OUP));
+  XCMP(1, OUP[0], 0);
+}
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+  enable_fp();
+  TEST_CASE1();
+  TEST_CASE2();
+  TEST_CASE3();
+  TEST_CASE4();
+  TEST_CASE5();
+  EXIT_CHECK();
+}

--- a/apps/riscv-tests/isa/rv64uv/vcpop.c
+++ b/apps/riscv-tests/isa/rv64uv/vcpop.c
@@ -37,7 +37,7 @@ void TEST_CASE2(void) {
   XCMP(1, OUP[0], 9);
 }
 
-// more elements, smaller elements, masked
+// number of elements that does not fill lanes, masked
 void TEST_CASE3(void) {
   VSET(6, e8, m1);
   VLOAD_8(v2, 0xf, 0x0, 0xf, 0x0, 0x3, 0x0);

--- a/apps/riscv-tests/isa/rv64uv/vpopc_m.c
+++ b/apps/riscv-tests/isa/rv64uv/vpopc_m.c
@@ -9,8 +9,8 @@
 
 void TEST_CASE1() {
   VSET(4, e32, m1);
-  VLOAD_U32(v2, 7, 0, 0, 0);
-  VLOAD_U32(v0, 5, 0, 0, 0);
+  VLOAD_32(v2, 7, 0, 0, 0);
+  VLOAD_32(v0, 5, 0, 0, 0);
   volatile uint32_t scalar = 1337;
   volatile uint32_t OUP[] = {0, 0, 0, 0};
   __asm__ volatile("vpopc.m %[A], v2, v0.t \n"

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -125,7 +125,9 @@ package ara_pkg;
     // Load instructions
     VLE, VLSE, VLXE,
     // Store instructions
-    VSE, VSSE, VSXE
+    VSE, VSSE, VSXE,
+    // Vector Mask instructions
+    VFIRST, VCPOP
   } ara_op_e;
 
   // Return true if op is a load operation

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -140,6 +140,14 @@ package ara_pkg;
     is_store = op inside {[VSE:VSXE]};
   endfunction : is_store
 
+  // Return true if op writes to a scalar register
+  // Beware when implementing further mask vector instructions:
+  // not all Chapter 15 instructions write to a scalar register! (e.g. viota)
+  // Some uses of this function will need to be differentiated!
+  function automatic vd_scalar(ara_op_e op);
+    vd_scalar = op inside {[VFIRST:VCPOP]};
+  endfunction : vd_scalar
+
   typedef enum logic [1:0] {
     NO_RED,
     ALU_RED,

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -129,6 +129,9 @@ module ara import ara_pkg::*; #(
   logic              [NrLanes-1:0] mfpu_vinsn_done;
   // Interface with the operand requesters
   logic [NrVInsn-1:0][NrVInsn-1:0] global_hazard_table;
+  // Interface with the Mask Unit
+  elen_t                        result_scalar;
+  logic                         result_scalar_valid;
 
   ara_sequencer #(.NrLanes(NrLanes)) i_sequencer (
     .clk_i                 (clk_i              ),
@@ -156,7 +159,10 @@ module ara import ara_pkg::*; #(
     // Interface with the address generator
     .addrgen_ack_i         (addrgen_ack        ),
     .addrgen_error_i       (addrgen_error      ),
-    .addrgen_error_vl_i    (addrgen_error_vl   )
+    .addrgen_error_vl_i    (addrgen_error_vl   ),
+    // Interface with the Mask Unit
+    .result_scalar_i       (result_scalar      ),
+    .result_scalar_valid_i (result_scalar_valid)
   );
 
   /////////////
@@ -400,6 +406,8 @@ module ara import ara_pkg::*; #(
     .pe_vinsn_running_i      (pe_vinsn_running                ),
     .pe_req_ready_o          (pe_req_ready[NrLanes+OffsetMask]),
     .pe_resp_o               (pe_resp[NrLanes+OffsetMask]     ),
+    .result_scalar_o         (result_scalar                   ),
+    .result_scalar_valid_o   (result_scalar_valid             ),
     // Interface with the lanes
     .masku_operand_i         (masku_operand                   ),
     .masku_operand_valid_i   (masku_operand_valid             ),

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -1019,7 +1019,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                       // Request is fulfilled, set valid bit to 0
                       ara_req_valid_d     = 1'b0;
                     end
-                    
+
                     case (insn.varith_type.rs1)
                       // 5'b00000: vmv.x.s
                       5'b10001: begin       // ara_pkg::VFIRST
@@ -1030,6 +1030,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                       end
                       5'b10000: begin
                         ara_req_d.op        = ara_pkg::VCPOP;
+                        ara_req_d.eew_vd_op = eew_q[insn.vmem_type.rs2];
                         // raise an illegal instruction exception if vstart is non-zero
                         if (ara_req_d.vstart != '0) begin
                           illegal_insn     = 1'b1;

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -2631,7 +2631,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
       // This operation is costly when occurs, so avoid it if the whole vector is overwritten
       // or if the register is empty or the destination register is a scalar register
       if (ara_req_valid_d && ara_req_d.use_vd && !acc_resp_o.error &&
-          !(ara_req_d.op inside {[VFIRST:VCPOP]}) &&
+          !(vd_scalar(ara_req_d.op)) &&
           ara_req_d.vtype.vsew != eew_q[ara_req_d.vd] && eew_valid_q[ara_req_d.vd] &&
           vl_q != VLENB >> ara_req_d.vtype.vsew) begin
         // Instruction is of one of the RVV types

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -2629,8 +2629,9 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
       // When a write occurs and the EEW is different, re-shuffle the content of the register
       // on the new EEW
       // This operation is costly when occurs, so avoid it if the whole vector is overwritten
-      // or if the register is empty
+      // or if the register is empty or the destination register is a scalar register
       if (ara_req_valid_d && ara_req_d.use_vd && !acc_resp_o.error &&
+          !(ara_req_d.op inside {[VFIRST:VCPOP]}) &&
           ara_req_d.vtype.vsew != eew_q[ara_req_d.vd] && eew_valid_q[ara_req_d.vd] &&
           vl_q != VLENB >> ara_req_d.vtype.vsew) begin
         // Instruction is of one of the RVV types

--- a/hardware/src/ara_sequencer.sv
+++ b/hardware/src/ara_sequencer.sv
@@ -300,14 +300,14 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
               write_list_d[VMASK].valid;
 
             // WAR
-            if (ara_req_i.use_vd && !(ara_req_i.op inside {[VFIRST:VCPOP]})) begin
+            if (ara_req_i.use_vd && !(vd_scalar(ara_req_i.op))) begin
               pe_req_d.hazard_vs1[read_list_d[ara_req_i.vd].vid] |= read_list_d[ara_req_i.vd].valid;
               pe_req_d.hazard_vs2[read_list_d[ara_req_i.vd].vid] |= read_list_d[ara_req_i.vd].valid;
               pe_req_d.hazard_vm[read_list_d[ara_req_i.vd].vid] |= read_list_d[ara_req_i.vd].valid;
             end
 
             // WAW
-            if (ara_req_i.use_vd && !(ara_req_i.op inside {[VFIRST:VCPOP]}))
+            if (ara_req_i.use_vd && !(vd_scalar(ara_req_i.op)))
               pe_req_d.hazard_vd[write_list_d[ara_req_i.vd].vid] |= write_list_d[ara_req_i.vd].valid;
 
             /////////////
@@ -395,7 +395,7 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
               pe_req_valid_d = 1'b1;
 
               // Mark that this vector instruction is writing to vector vd
-              if (ara_req_i.use_vd && !(ara_req_i.op inside {[VFIRST:VCPOP]}))
+              if (ara_req_i.use_vd && !(vd_scalar(ara_req_i.op)))
                 write_list_d[ara_req_i.vd] = '{vid: vinsn_id_n, valid: 1'b1};
 
               // Mark that this loop is reading vs

--- a/hardware/src/ara_sequencer.sv
+++ b/hardware/src/ara_sequencer.sv
@@ -307,7 +307,7 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
             end
 
             // WAW
-            if (ara_req_i.use_vd && !(ara_req_i.op inside {[VFIRST:VCPOP]})) 
+            if (ara_req_i.use_vd && !(ara_req_i.op inside {[VFIRST:VCPOP]}))
               pe_req_d.hazard_vd[write_list_d[ara_req_i.vd].vid] |= write_list_d[ara_req_i.vd].valid;
 
             /////////////
@@ -395,7 +395,7 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
               pe_req_valid_d = 1'b1;
 
               // Mark that this vector instruction is writing to vector vd
-              if (ara_req_i.use_vd && !(ara_req_i.op inside {[VFIRST:VCPOP]})) 
+              if (ara_req_i.use_vd && !(ara_req_i.op inside {[VFIRST:VCPOP]}))
                 write_list_d[ara_req_i.vd] = '{vid: vinsn_id_n, valid: 1'b1};
 
               // Mark that this loop is reading vs

--- a/hardware/src/ara_sequencer.sv
+++ b/hardware/src/ara_sequencer.sv
@@ -40,7 +40,10 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
     // Interface with the Address Generation
     input  logic                            addrgen_ack_i,
     input  logic                            addrgen_error_i,
-    input  vlen_t                           addrgen_error_vl_i
+    input  vlen_t                           addrgen_error_vl_i,
+    // Interface with the Mask Unit
+    input  elen_t                           result_scalar_i,
+    input  logic                            result_scalar_valid_i
   );
 
   ///////////////////////////////////
@@ -154,6 +157,7 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
       [VADD:VWREDSUM]      : vfu = VFU_Alu;
       [VMUL:VFCVTFF]       : vfu = VFU_MFpu;
       [VMFEQ:VMXNOR]       : vfu = VFU_MaskUnit;
+      [VFIRST:VCPOP]       : vfu = VFU_MaskUnit;
       [VLE:VLXE]           : vfu = VFU_LoadUnit;
       [VSE:VSXE]           : vfu = VFU_StoreUnit;
       [VSLIDEUP:VSLIDEDOWN]: vfu = VFU_SlideUnit;
@@ -178,6 +182,9 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
       [VMSEQ:VMXNOR]:
         for (int i = 0; i < NrVFUs; i++)
           if (i == VFU_Alu || i == VFU_MaskUnit) target_vfus[i] = 1'b1;
+      [VFIRST:VCPOP]:
+        for (int i = 0; i < NrVFUs; i++)
+          if (i == VFU_MaskUnit) target_vfus[i] = 1'b1;
       [VMFEQ:VMFGE]:
         for (int i = 0; i < NrVFUs; i++)
           if (i == VFU_MFpu || i == VFU_MaskUnit) target_vfus[i] = 1'b1;
@@ -293,15 +300,15 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
               write_list_d[VMASK].valid;
 
             // WAR
-            if (ara_req_i.use_vd) begin
+            if (ara_req_i.use_vd && !(ara_req_i.op inside {[VFIRST:VCPOP]})) begin
               pe_req_d.hazard_vs1[read_list_d[ara_req_i.vd].vid] |= read_list_d[ara_req_i.vd].valid;
               pe_req_d.hazard_vs2[read_list_d[ara_req_i.vd].vid] |= read_list_d[ara_req_i.vd].valid;
               pe_req_d.hazard_vm[read_list_d[ara_req_i.vd].vid] |= read_list_d[ara_req_i.vd].valid;
             end
 
             // WAW
-            if (ara_req_i.use_vd) pe_req_d.hazard_vd[write_list_d[ara_req_i.vd].vid] |=
-              write_list_d[ara_req_i.vd].valid;
+            if (ara_req_i.use_vd && !(ara_req_i.op inside {[VFIRST:VCPOP]})) 
+              pe_req_d.hazard_vd[write_list_d[ara_req_i.vd].vid] |= write_list_d[ara_req_i.vd].valid;
 
             /////////////
             //  Issue  //
@@ -388,7 +395,8 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
               pe_req_valid_d = 1'b1;
 
               // Mark that this vector instruction is writing to vector vd
-              if (ara_req_i.use_vd) write_list_d[ara_req_i.vd] = '{vid: vinsn_id_n, valid: 1'b1};
+              if (ara_req_i.use_vd && !(ara_req_i.op inside {[VFIRST:VCPOP]})) 
+                write_list_d[ara_req_i.vd] = '{vid: vinsn_id_n, valid: 1'b1};
 
               // Mark that this loop is reading vs
               if (ara_req_i.use_vs1) read_list_d[ara_req_i.vs1] = '{vid: vinsn_id_n, valid: 1'b1};
@@ -396,6 +404,17 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
               if (!ara_req_i.vm) read_list_d[VMASK]             = '{vid: vinsn_id_n, valid: 1'b1};
             end
           end else ara_req_ready_o = 1'b0; // Wait until the PEs are ready
+        end
+
+        ////////////////////
+        // Scalar results //
+        ////////////////////
+
+        if (result_scalar_valid_i) begin
+          ara_resp_o.resp     = result_scalar_i;
+          ara_resp_o.error    = '0;
+          ara_resp_o.error_vl = '0;
+          ara_resp_valid_o    = 1'b1;
         end
       end
 

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -632,33 +632,21 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
           operand_request_i[MulFPUB].vl = vfu_operation_d.vl;
           operand_request_push[MulFPUB] = pe_req.use_vs2 && pe_req.op inside {[VMFEQ:VMFGE]};
 
-          // these instructions send vs2 to the MaskB channel
-          operand_request_i[MaskB] = pe_req.op inside {[VFIRST:VCPOP]} ?
-          '{
+          // [VFIRST:VCPOP]         : send vs2 to the MaskB channel 
+          // all other instructions : send vd  to the MaskB channel
+          operand_request_i[MaskB] = {
             id      : pe_req.id,
-            vs      : pe_req.vs2,
-            eew     : pe_req.eew_vs2,
+            vs      : pe_req.op inside {[VFIRST:VCPOP]} ? pe_req.vs2     : pe_req.vd,
+            eew     : pe_req.op inside {[VFIRST:VCPOP]} ? pe_req.eew_vs2 : pe_req.eew_vd_op,
             scale_vl: pe_req.scale_vl,
             vtype   : pe_req.vtype,
             // Since this request goes outside of the lane, we might need to request an
             // extra operand regardless of whether it is valid in this lane or not.
-            vl      : (pe_req.vl / NrLanes / ELEN) << (int'(EW64) - int'(pe_req.eew_vs2)),
+            vl      : pe_req.op inside {[VFIRST:VCPOP]} ?
+                      (pe_req.vl / NrLanes / ELEN) << (int'(EW64) - int'(pe_req.eew_vs2)) :
+                      (pe_req.vl / NrLanes / ELEN) << (int'(EW64) - int'(pe_req.vtype.vsew)),
             vstart  : vfu_operation_d.vstart,
-            hazard  : pe_req.hazard_vs2,
-            default : '0
-          } :
-          // all other instrutions: send vd to MaskB channel
-          '{
-            id      : pe_req.id,
-            vs      : pe_req.vd,
-            eew     : pe_req.eew_vd_op,
-            scale_vl: pe_req.scale_vl,
-            vtype   : pe_req.vtype,
-            // Since this request goes outside of the lane, we might need to request an
-            // extra operand regardless of whether it is valid in this lane or not.
-            vl      : (pe_req.vl / NrLanes / ELEN) << (int'(EW64) - int'(pe_req.vtype.vsew)),
-            vstart  : vfu_operation_d.vstart,
-            hazard  : pe_req.hazard_vd,
+            hazard  : pe_req.op inside {[VFIRST:VCPOP]} ? pe_req.hazard_vs2 : pe_req.hazard_vd,
             default : '0
           };
           if (((pe_req.vl / NrLanes / ELEN) * NrLanes * ELEN) !=

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -634,7 +634,7 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
 
           // vd_scalar              : send vs2 to the MaskB channel 
           // all other instructions : send vd  to the MaskB channel
-          operand_request_i[MaskB] = {
+          operand_request_i[MaskB] = '{
             id      : pe_req.id,
             vs      : vd_scalar(pe_req.op) ? pe_req.vs2     : pe_req.vd,
             eew     : vd_scalar(pe_req.op) ? pe_req.eew_vs2 : pe_req.eew_vd_op,

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -643,8 +643,8 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
             hazard  : pe_req.hazard_vd,
             default : '0
           };
-          if ((pe_req.vl / NrLanes / ELEN) << (int'(EW64) - int'(pe_req.vtype.vsew)) !=
-              pe_req.vl) operand_request_i[MaskB].vl += 1;
+          if (((pe_req.vl / NrLanes / ELEN) * NrLanes * ELEN) !=
+            pe_req.vl) operand_request_i[MaskB].vl += 1;
           operand_request_push[MaskB] = pe_req.use_vd_op;
 
           operand_request_i[MaskM] = '{

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -265,7 +265,7 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
             hazard     : pe_req.hazard_vs2 | pe_req.hazard_vd,
             default    : '0
           };
-          operand_request_push[AluB] = pe_req.use_vs2;
+          operand_request_push[AluB] = pe_req.use_vs2 && !(pe_req.op inside {[VFIRST:VCPOP]});
 
           // This vector instruction uses masks
           operand_request_i[MaskM] = '{
@@ -597,7 +597,7 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
             if ((operand_request_i[AluB].vl << (int'(EW64) - int'(pe_req.eew_vs2))) * NrLanes !=
                 pe_req.vl) operand_request_i[AluB].vl += 1;
           end
-          operand_request_push[AluB] = pe_req.use_vs2 && !(pe_req.op inside {[VMFEQ:VMFGE]});
+          operand_request_push[AluB] = pe_req.use_vs2 && !(pe_req.op inside {[VMFEQ:VMFGE], [VFIRST:VCPOP]});
 
           operand_request_i[MulFPUA] = '{
             id      : pe_req.id,
@@ -630,7 +630,23 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
           operand_request_i[MulFPUB].vl = (pe_req.vl + NrLanes - 1) / NrLanes;
           operand_request_push[MulFPUB] = pe_req.use_vs2 && pe_req.op inside {[VMFEQ:VMFGE]};
 
-          operand_request_i[MaskB] = '{
+          // these instructions send vs2 to the MaskB channel
+          operand_request_i[MaskB] = pe_req.op inside {[VFIRST:VCPOP]} ? 
+          '{
+            id      : pe_req.id,
+            vs      : pe_req.vs2,
+            eew     : pe_req.eew_vs2,
+            scale_vl: pe_req.scale_vl,
+            vtype   : pe_req.vtype,
+            // Since this request goes outside of the lane, we might need to request an
+            // extra operand regardless of whether it is valid in this lane or not.
+            vl      : (pe_req.vl / NrLanes / ELEN) << (int'(EW64) - int'(pe_req.vtype.vsew)),
+            vstart  : vfu_operation_d.vstart,
+            hazard  : pe_req.hazard_vs2,
+            default : '0
+          } :
+          // all other instrutions: send vd to MaskB channel
+          '{
             id      : pe_req.id,
             vs      : pe_req.vd,
             eew     : pe_req.eew_vd_op,
@@ -645,7 +661,7 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
           };
           if (((pe_req.vl / NrLanes / ELEN) * NrLanes * ELEN) !=
             pe_req.vl) operand_request_i[MaskB].vl += 1;
-          operand_request_push[MaskB] = pe_req.use_vd_op;
+          operand_request_push[MaskB] = pe_req.use_vd_op || pe_req.op inside {[VFIRST:VCPOP]};
 
           operand_request_i[MaskM] = '{
             id     : pe_req.id,

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -632,7 +632,7 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
           operand_request_i[MulFPUB].vl = vfu_operation_d.vl;
           operand_request_push[MulFPUB] = pe_req.use_vs2 && pe_req.op inside {[VMFEQ:VMFGE]};
 
-          // vd_scalar              : send vs2 to the MaskB channel 
+          // vd_scalar              : send vs2 to the MaskB channel
           // all other instructions : send vd  to the MaskB channel
           operand_request_i[MaskB] = '{
             id      : pe_req.id,

--- a/hardware/src/lane/valu.sv
+++ b/hardware/src/lane/valu.sv
@@ -426,7 +426,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
               alu_operand_ready_o = {vinsn_issue_q.use_vs2, vinsn_issue_q.use_vs1};
               // Narrowing instructions might need an extra cycle before acknowledging the mask operands
               // If the results are being sent to the Mask Unit, it is up to it to acknowledge the operands.
-              if (!narrowing(vinsn_issue_q.op) && vinsn_issue_q != VFU_MaskUnit)
+              if (!narrowing(vinsn_issue_q.op) && vinsn_issue_q.vfu != VFU_MaskUnit)
                 mask_ready_o = !vinsn_issue_q.vm;
 
               // Store the result in the result queue
@@ -455,7 +455,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
                   result_queue_valid_d[result_queue_write_pnt_q] = 1'b1;
 
                   // Acknowledge the mask operand, if needed
-                  if (vinsn_issue_q != VFU_MaskUnit)
+                  if (vinsn_issue_q.vfu != VFU_MaskUnit)
                     mask_ready_o = !vinsn_issue_q.vm;
 
                   // Bump pointers and counters of the result queue
@@ -489,7 +489,14 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
                   vinsn_queue_d.issue_pnt = vinsn_queue_q.issue_pnt + 1;
 
                 if (vinsn_queue_d.issue_cnt != 0)
-                  issue_cnt_d = vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vl;
+                  if (!(vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].op inside {[VMANDNOT:VMXNOR]}))
+                    issue_cnt_d = vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vl;
+                  else begin
+                    // Operations between mask vectors operate on bits
+                    issue_cnt_d = (vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vl / 8) >>
+                      vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vtype.vsew;
+                    issue_cnt_d += |vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vl[2:0];
+                  end
               end
             end
           end
@@ -559,7 +566,13 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
                   vinsn_queue_d.issue_pnt = vinsn_queue_q.issue_pnt + 1;
 
                 if (vinsn_queue_d.issue_cnt != 0)
-                  issue_cnt_d = vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vl;
+                  if (!(vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].op inside {[VMANDNOT:VMXNOR]}))
+                    issue_cnt_d = vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vl;
+                  else begin
+                    issue_cnt_d = (vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vl / 8) >>
+                      vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vtype.vsew;
+                    issue_cnt_d += |vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vl[2:0];
+                  end
               end
             end
           end else begin
@@ -642,7 +655,13 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
                 vinsn_queue_d.issue_pnt = vinsn_queue_q.issue_pnt + 1;
 
               if (vinsn_queue_d.issue_cnt != 0)
-                issue_cnt_d = vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vl;
+                if (!(vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].op inside {[VMANDNOT:VMXNOR]}))
+                  issue_cnt_d = vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vl;
+                else begin
+                  issue_cnt_d = (vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vl / 8) >>
+                    vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vtype.vsew;;
+                  issue_cnt_d += |vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vl[2:0];
+                end
 
               alu_state_d = is_reduction(vinsn_issue_d.op) && (vinsn_queue_d.issue_cnt != 0) ? INTRA_LANE_REDUCTION : NO_REDUCTION;
               // The next will be the first operation of this instruction
@@ -683,6 +702,10 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
     alu_result_id_o   = result_queue_q[result_queue_read_pnt_q].id;
     alu_result_be_o   = result_queue_q[result_queue_read_pnt_q].be;
 
+    // Clear the accumulator after a partial reduction
+    if (alu_state_q == WAIT_STATE && alu_state_d == NO_REDUCTION)
+      result_queue_d[result_queue_read_pnt_q] = '0;
+
     // Received a grant from the VRF.
     // Deactivate the request.
     if (alu_result_gnt_i || mask_operand_gnt) begin
@@ -714,8 +737,30 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
       else vinsn_queue_d.commit_pnt += 1;
 
       // Update the commit counter for the next instruction
-      if (vinsn_queue_d.commit_cnt != '0) commit_cnt_d =
-        vinsn_queue_q.vinsn[vinsn_queue_d.commit_pnt].vl;
+      if (vinsn_queue_d.commit_cnt != '0)
+        if (!(vinsn_queue_q.vinsn[vinsn_queue_d.commit_pnt].op inside {[VMANDNOT:VMXNOR]}))
+          commit_cnt_d = vinsn_queue_q.vinsn[vinsn_queue_d.commit_pnt].vl;
+        else begin
+          // We are asking for bits, and we want at least one chunk of bits if
+          // vl > 0. Therefore, commit_cnt = ceil((vl / 8) >> sew)
+          commit_cnt_d = (vinsn_queue_q.vinsn[vinsn_queue_d.commit_pnt].vl / 8) >>
+            vinsn_queue_q.vinsn[vinsn_queue_d.commit_pnt].vtype.vsew;
+          commit_cnt_d += |vinsn_queue_q.vinsn[vinsn_queue_d.commit_pnt].vl[2:0];
+        end
+
+      // Initialize counters and alu state if needed by the next instruction
+      if (is_reduction(vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].op)) begin
+        alu_state_d = INTRA_LANE_REDUCTION;
+        // The next will be the first operation of this instruction
+        // This information is useful for reduction operation
+        first_op_d         = 1'b1;
+        reduction_rx_cnt_d = reduction_rx_cnt_init(NrLanes, lane_id_i);
+
+        sldu_transactions_cnt_d = $clog2(NrLanes) + 1;
+        // Allow the first valid
+        red_hs_synch_d = 1'b1;
+        issue_cnt_d    = vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vl;
+      end
     end
 
     //////////////////////////////
@@ -742,7 +787,14 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
         red_hs_synch_d = 1'b1;
         issue_cnt_d    = vfu_operation_i.vl;
       end
-      if (vinsn_queue_d.commit_cnt == '0) commit_cnt_d = vfu_operation_i.vl;
+      if (vinsn_queue_d.commit_cnt == '0)
+        if (!(vfu_operation_i.op inside {[VMANDNOT:VMXNOR]}))
+          commit_cnt_d = vfu_operation_i.vl;
+        else begin
+          // Operations between mask vectors operate on bits
+          commit_cnt_d  = (vfu_operation_i.vl / 8) >> vfu_operation_i.vtype.vsew;
+          commit_cnt_d += |vfu_operation_i.vl[2:0];
+        end
 
       // Bump pointers and counters of the vector instruction queue
       vinsn_queue_d.accept_pnt += 1;

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -410,7 +410,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
         VCPOP : begin
           vcpop_to_count = masku_operand_b_i & bit_enable_mask;
         end
-        default: alu_result = '0;   
+        default: alu_result = '0;
       endcase
     end
   end: p_mask_alu
@@ -488,7 +488,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
 
     // Is there an instruction ready to be issued?
     if (vinsn_issue_valid && !(vinsn_issue.op inside {[VFIRST:VCPOP]})) begin
-      
+
       // Is there place in the mask queue to write the mask operands?
       // Did we receive the mask bits on the MaskM channel?
       if (!vinsn_issue.vm && !mask_queue_full && &masku_operand_m_valid_i) begin
@@ -695,7 +695,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
         end
       end
     end
-      
+
 
     /////////////////////////////////// INDEPENDENT //////////////////////////////
 
@@ -717,7 +717,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
     //  Send operands to the VFUs  // : commit stage, mask path
     /////////////////////////////////
 
-    // [VFIRST:VCPOP] instructions don't use the mask queue, 
+    // [VFIRST:VCPOP] instructions don't use the mask queue,
     // but this section interferes with the commit_cnt
     if (!(vinsn_commit.op inside {[VFIRST:VCPOP]})) begin
 
@@ -819,7 +819,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
 
     // The scalar result has been sent to and acknowledged by the dispatcher
     if (vinsn_commit.op == VCPOP && result_scalar_valid_o == 1) begin
-      
+
       // reset result_scalar
       result_scalar_d       = '0;
       result_scalar_valid_d = '0;

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -257,7 +257,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
       // from the previous value of the destination register (mask_operand_b_i). Byte strobes
       // do not work here, since this has to be done at a bit granularity. Therefore, the Mask Unit
       // received both operands, and does a masking depending on the value of the vl.
-      if (vinsn_issue.vl > ELEN*NrLanes)
+      if (vinsn_issue.vl >= ELEN*NrLanes)
         bit_enable = '1;
       else begin
         bit_enable[vinsn_issue.vl] = 1'b1;

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -498,7 +498,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
     /////////////////////
 
     // Is there an instruction ready to be issued?
-    if (vinsn_issue_valid && !(vinsn_issue.op inside {[VFIRST:VCPOP]})) begin
+    if (vinsn_issue_valid && !(vd_scalar(vinsn_issue.op))) begin
 
       // Is there place in the mask queue to write the mask operands?
       // Did we receive the mask bits on the MaskM channel?
@@ -674,7 +674,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
     //////////////////////////////
 
     // Is there an instruction ready to be issued?
-    if (vinsn_issue_valid && vinsn_issue.op inside {[VFIRST:VCPOP]}) begin
+    if (vinsn_issue_valid && vd_scalar(vinsn_issue.op)) begin
       if (masku_operand_b_valid_i && (masku_operand_m_valid_i || vinsn_issue.vm)) begin
         // accumulate popcounts in the popcount register
         for (int lane = 0; lane < NrLanes; lane++) begin
@@ -722,9 +722,9 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
     //  Send operands to the VFUs  // : commit stage, mask path
     /////////////////////////////////
 
-    // [VFIRST:VCPOP] instructions don't use the mask queue,
+    // vd_scalar() instructions don't use the mask queue,
     // but this section interferes with the commit_cnt
-    if (!(vinsn_commit.op inside {[VFIRST:VCPOP]})) begin
+    if (!(vd_scalar(vinsn_commit.op))) begin
 
       for (int lane = 0; lane < NrLanes; lane++) begin: send_operand
         mask_valid_o[lane] = mask_queue_valid_q[mask_queue_read_pnt_q][lane];

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -716,7 +716,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
     end
 
     //////////////// END OF ISSUE STAGE, BEGIN OF COMMIT STAGE ////////////////
-    
+
 
     /////////////////////////////////
     //  Send operands to the VFUs  // : commit stage, mask path


### PR DESCRIPTION
This PR adds implementation and test for instruction (`vcpop.m`) that previously had the assembler mnemonic `vpopc.m` but was renamed to be consistent with the scalar instruction.

## Changelog

### Fixed

- None

### Added

- Added `vcpop.c` test file (modified copy of `vpopc_m.c`) to add test for mnemonic update 

### Changed

- None

## Checklist

- [ ] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed