### PR TITLE
Vmandn vmorn

### DIFF
--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -107,9 +107,11 @@ rv64uv_sc_tests = vadd \
                   vfncvt \
                   vmand \
                   vmnand \
+                  vmandn \
                   vmandnot \
                   vmor \
                   vmnor \
+                  vmorn \
                   vmornot \
                   vmxor \
                   vmxnor \

--- a/apps/riscv-tests/isa/rv64uv/vmandn.c
+++ b/apps/riscv-tests/isa/rv64uv/vmandn.c
@@ -1,0 +1,68 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
+//         Basile Bougenot <bbougenot@student.ethz.ch>
+
+#include "vector_macros.h"
+
+void TEST_CASE1() {
+  VSET(16, e8, m1);
+  VLOAD_8(v2, 0xCD, 0xEF);
+  VLOAD_8(v3, 0x84, 0x21);
+  asm volatile("vmandn.mm v1, v2, v3");
+  VSET(2, e8, m1);
+  VCMP_U8(1, v1, 0x49, 0xCE);
+}
+
+void TEST_CASE2() {
+  VSET(16, e8, m1);
+  VLOAD_8(v2, 0xCD, 0xEF);
+  VLOAD_8(v3, 0xFF, 0xFF);
+  asm volatile("vmandn.mm v1, v2, v3");
+  VSET(2, e8, m1);
+  VCMP_U8(2, v1, 0x00, 0x00);
+}
+
+void TEST_CASE3() {
+  VSET(16, e8, m1);
+  VLOAD_8(v2, 0xCD, 0xEF);
+  VLOAD_8(v3, 0x00, 0x00);
+  asm volatile("vmandn.mm v1, v2, v3");
+  VSET(2, e8, m1);
+  VCMP_U8(3, v1, 0xCD, 0xEF);
+}
+
+void TEST_CASE4() {
+  VSET(16, e8, m1);
+  VLOAD_8(v2, 0xCD, 0xEF);
+  VLOAD_8(v3, 0x0F, 0xF0);
+  asm volatile("vmandn.mm v1, v2, v3");
+  VSET(2, e8, m1);
+  VCMP_U8(4, v1, 0xC0, 0x0F);
+}
+
+void TEST_CASE5() {
+  VSET(16, e8, m1);
+  VLOAD_8(v1, 0xFF, 0xFF);
+  VLOAD_8(v2, 0xCD, 0xEF);
+  VLOAD_8(v3, 0x84, 0x21);
+  VSET(13, e8, m1);
+  asm volatile("vmandn.mm v1, v2, v3");
+  VSET(2, e8, m1);
+  VCMP_U8(5, v1, 0x49, 0xEE);
+}
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+
+  TEST_CASE1();
+  TEST_CASE2();
+  TEST_CASE3();
+  TEST_CASE4();
+  TEST_CASE5();
+
+  EXIT_CHECK();
+}

--- a/apps/riscv-tests/isa/rv64uv/vmorn.c
+++ b/apps/riscv-tests/isa/rv64uv/vmorn.c
@@ -1,0 +1,68 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
+//         Basile Bougenot <bbougenot@student.ethz.ch>
+
+#include "vector_macros.h"
+
+void TEST_CASE1() {
+  VSET(16, e8, m1);
+  VLOAD_8(v2, 0xCD, 0xEF);
+  VLOAD_8(v3, 0x84, 0x21);
+  asm volatile("vmorn.mm v1, v2, v3");
+  VSET(2, e8, m1);
+  VCMP_U8(1, v1, 0xFF, 0xFF);
+}
+
+void TEST_CASE2() {
+  VSET(16, e8, m1);
+  VLOAD_8(v2, 0xCD, 0xEF);
+  VLOAD_8(v3, 0xFF, 0xFF);
+  asm volatile("vmorn.mm v1, v2, v3");
+  VSET(2, e8, m1);
+  VCMP_U8(2, v1, 0xCD, 0xEF);
+}
+
+void TEST_CASE3() {
+  VSET(16, e8, m1);
+  VLOAD_8(v2, 0xCD, 0xEF);
+  VLOAD_8(v3, 0x00, 0x00);
+  asm volatile("vmorn.mm v1, v2, v3");
+  VSET(2, e8, m1);
+  VCMP_U8(3, v1, 0xFF, 0xFF);
+}
+
+void TEST_CASE4() {
+  VSET(16, e8, m1);
+  VLOAD_8(v2, 0xCD, 0xEF);
+  VLOAD_8(v3, 0x0F, 0xF0);
+  asm volatile("vmorn.mm v1, v2, v3");
+  VSET(2, e8, m1);
+  VCMP_U8(4, v1, 0xFD, 0xEF);
+}
+
+void TEST_CASE5() {
+  VSET(16, e8, m1);
+  VLOAD_8(v1, 0xFF, 0xFF);
+  VLOAD_8(v2, 0xCD, 0xEF);
+  VLOAD_8(v3, 0x84, 0x21);
+  VSET(13, e8, m1);
+  asm volatile("vmorn.mm v1, v2, v3");
+  VSET(2, e8, m1);
+  VCMP_U8(5, v1, 0xFF, 0xFF);
+}
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+
+  TEST_CASE1();
+  TEST_CASE2();
+  TEST_CASE3();
+  TEST_CASE4();
+  TEST_CASE5();
+
+  EXIT_CHECK();
+}

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -121,7 +121,7 @@ package ara_pkg;
     // Integer add-with-carry and subtract-with-borrow carry-out instructions
     VMADC, VMSBC,
     // Mask operations
-    VMANDNOT, VMAND, VMOR, VMXOR, VMORNOT, VMNAND, VMNOR, VMXNOR,
+    VMANDN, VMAND, VMOR, VMXOR, VMORN, VMNAND, VMNOR, VMXNOR,
     // Slide instructions
     VSLIDEUP, VSLIDEDOWN,
     // Load instructions

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -989,7 +989,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     ara_req_d.cvt_resize     = resize_e'(2'b10);
                   end
                   6'b011000: begin
-                    ara_req_d.op        = ara_pkg::VMANDNOT;
+                    ara_req_d.op        = ara_pkg::VMANDN;
                     ara_req_d.use_vd_op = 1'b1;
                   end
                   6'b011001: begin
@@ -1005,7 +1005,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     ara_req_d.use_vd_op = 1'b1;
                   end
                   6'b011100: begin
-                    ara_req_d.op        = ara_pkg::VMORNOT;
+                    ara_req_d.op        = ara_pkg::VMORN;
                     ara_req_d.use_vd_op = 1'b1;
                   end
                   6'b011101: begin

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -103,11 +103,11 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
 
         // Mask logical operations
         VMAND   : res = operand_a_i & operand_b_i;
-        VMANDNOT: res = ~operand_a_i & operand_b_i;
+        VMANDN: res = ~operand_a_i & operand_b_i;
         VMNAND  : res = ~(operand_a_i & operand_b_i);
         VMOR    : res = operand_a_i | operand_b_i;
         VMNOR   : res = ~(operand_a_i | operand_b_i);
-        VMORNOT : res = ~operand_a_i | operand_b_i;
+        VMORN : res = ~operand_a_i | operand_b_i;
         VMXOR   : res = operand_a_i ^ operand_b_i;
         VMXNOR  : res = ~(operand_a_i ^ operand_b_i);
 

--- a/hardware/src/lane/valu.sv
+++ b/hardware/src/lane/valu.sv
@@ -490,7 +490,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
                   vinsn_queue_d.issue_pnt = vinsn_queue_q.issue_pnt + 1;
 
                 if (vinsn_queue_d.issue_cnt != 0)
-                  if (!(vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].op inside {[VMANDNOT:VMXNOR]}))
+                  if (!(vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].op inside {[VMANDN:VMXNOR]}))
                     issue_cnt_d = vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vl;
                   else begin
                     // Operations between mask vectors operate on bits
@@ -567,7 +567,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
                   vinsn_queue_d.issue_pnt = vinsn_queue_q.issue_pnt + 1;
 
                 if (vinsn_queue_d.issue_cnt != 0)
-                  if (!(vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].op inside {[VMANDNOT:VMXNOR]}))
+                  if (!(vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].op inside {[VMANDN:VMXNOR]}))
                     issue_cnt_d = vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vl;
                   else begin
                     issue_cnt_d = (vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vl / 8) >>
@@ -656,7 +656,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
                 vinsn_queue_d.issue_pnt = vinsn_queue_q.issue_pnt + 1;
 
               if (vinsn_queue_d.issue_cnt != 0)
-                if (!(vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].op inside {[VMANDNOT:VMXNOR]}))
+                if (!(vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].op inside {[VMANDN:VMXNOR]}))
                   issue_cnt_d = vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vl;
                 else begin
                   issue_cnt_d = (vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vl / 8) >>
@@ -739,7 +739,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
 
       // Update the commit counter for the next instruction
       if (vinsn_queue_d.commit_cnt != '0)
-        if (!(vinsn_queue_q.vinsn[vinsn_queue_d.commit_pnt].op inside {[VMANDNOT:VMXNOR]}))
+        if (!(vinsn_queue_q.vinsn[vinsn_queue_d.commit_pnt].op inside {[VMANDN:VMXNOR]}))
           commit_cnt_d = vinsn_queue_q.vinsn[vinsn_queue_d.commit_pnt].vl;
         else begin
           // We are asking for bits, and we want at least one chunk of bits if
@@ -790,7 +790,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
         issue_cnt_d    = vfu_operation_i.vl;
       end
       if (vinsn_queue_d.commit_cnt == '0)
-        if (!(vfu_operation_i.op inside {[VMANDNOT:VMXNOR]}))
+        if (!(vfu_operation_i.op inside {[VMANDN:VMXNOR]}))
           commit_cnt_d = vfu_operation_i.vl;
         else begin
           // Operations between mask vectors operate on bits

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -283,7 +283,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
 
       // Evaluate the instruction
       unique case (vinsn_issue.op) inside
-        [VMANDNOT:VMXNOR]: alu_result = (masku_operand_a_i & bit_enable_mask) |
+        [VMANDN:VMXNOR]: alu_result = (masku_operand_a_i & bit_enable_mask) |
           (masku_operand_b_i & ~bit_enable_mask);
         [VMFEQ:VMSBC] : begin
           automatic logic [ELEN*NrLanes-1:0] alu_result_flat = '0;


### PR DESCRIPTION
This PR adds modification in implementation and test for instructions (`vmorn` and `vmandn`) that previously had the assembler mnemonics `vmornot` and `vmandnot` respectively.

## Changelog

### Fixed

- none

### Added

- Additional tests for `vmandn` as well as `vmorn` added while keeping the tests with previous mnemonics as well

### Changed

- `vmandnot` is changed to `vmandn` in RTL implementation
- `vmornot` is changed to `vmorn` in RTL implementation

## Checklist

- [ ] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
