### PR TITLE
Vfixed point draft vxsat vxrm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+ - Fixed-Point instructions were added (`VSADDU`, `VSADD`, `VAADD`, `VAADDU`, `VSSUBU`, `VSSUB`, `VASUB`, `VASUBU`)
  - The main sequencer issues instructions every time the target unit has a non-full instruction queue
  - The main sequencer stalls if the instructions target a lane, and its operand requesters are not ready
  - New instructions enter the main sequencer with a token that marks them as new, and the related counter is updated upon arrival

--- a/FUNCTIONALITIES.md
+++ b/FUNCTIONALITIES.md
@@ -65,3 +65,8 @@ This file specifies the functionalities of the RISC-V Vector Specification suppo
 ## Vector permutation instructions
 
 - Vector slide instructions: `vslideup`, `vslidedown`, `vslide1up`, `vfslide1up`, `vslide1down`, `vfslide1down`
+
+## Vector fixed-point arithmetic instructions
+
+- Vector single-width saturating add and subtract: `vsaddu`, `vsadd`, `vssubu`,`vssub`
+- Vector single-width averaging add and subtract: `vaadd`, `vaaddu`, `vasub`, `vasubu`

--- a/apps/riscv-tests/isa/macros/vector/vector_macros.h
+++ b/apps/riscv-tests/isa/macros/vector/vector_macros.h
@@ -44,6 +44,7 @@ int test_case;
 #define read_vl(buf)    do { asm volatile ("csrr %[BUF], vl" : [BUF] "=r" (buf)); } while (0);
 #define read_mstatus(buf) do { asm volatile ("csrr %[BUF], mstatus" : [BUF] "=r" (buf)); } while (0);
 #define read_misa(buf) do { asm volatile ("csrr %[BUF], misa" : [BUF] "=r" (buf)); } while (0);
+#define read_vxsat(buf) do { asm volatile ("csrr %[BUF], vxsat" : [BUF] "=r" (buf)); } while (0);
 
 #define vtype(golden_vtype, vlmul, vsew, vta, vma) (golden_vtype = vlmul << 0 | vsew << 3 | vta << 6 | vma << 7)
 
@@ -69,6 +70,15 @@ int test_case;
   printf("Checking misa.%s field:\n", field);                                                                      \
   if (misa != golden_misa) {                                                                                       \
     printf("FAILED. Got misa = %lx, expected misa = %lx.\n", misa, golden_misa);                                   \
+    num_failed++;                                                                                                  \
+    return;                                                                                                        \
+  }                                                                                                                \
+  printf("PASSED.\n");
+
+#define check_vxsat(casenum, vxsat, golden_vxsat)                                                                  \
+  printf("Checking vxsat #%d...\n", casenum);                                                                      \
+  if (vxsat != golden_vxsat) {                                                                                     \
+    printf("FAILED. Got vxsat = %lx, expected vxsat = %lx.\n", vxsat, golden_vxsat);                               \
     num_failed++;                                                                                                  \
     return;                                                                                                        \
   }                                                                                                                \

--- a/apps/riscv-tests/isa/macros/vector/vector_macros.h
+++ b/apps/riscv-tests/isa/macros/vector/vector_macros.h
@@ -45,6 +45,7 @@ int test_case;
 #define read_mstatus(buf) do { asm volatile ("csrr %[BUF], mstatus" : [BUF] "=r" (buf)); } while (0);
 #define read_misa(buf) do { asm volatile ("csrr %[BUF], misa" : [BUF] "=r" (buf)); } while (0);
 #define read_vxsat(buf) do { asm volatile ("csrr %[BUF], vxsat" : [BUF] "=r" (buf)); } while (0);
+#define set_vxrm(val) do { asm volatile ("csrw vxrm, %0" :: "rK"(val)); } while (0);
 
 #define vtype(golden_vtype, vlmul, vsew, vta, vma) (golden_vtype = vlmul << 0 | vsew << 3 | vta << 6 | vma << 7)
 

--- a/apps/riscv-tests/isa/macros/vector/vector_macros.h
+++ b/apps/riscv-tests/isa/macros/vector/vector_macros.h
@@ -45,6 +45,7 @@ int test_case;
 #define read_mstatus(buf) do { asm volatile ("csrr %[BUF], mstatus" : [BUF] "=r" (buf)); } while (0);
 #define read_misa(buf) do { asm volatile ("csrr %[BUF], misa" : [BUF] "=r" (buf)); } while (0);
 #define read_vxsat(buf) do { asm volatile ("csrr %[BUF], vxsat" : [BUF] "=r" (buf)); } while (0);
+#define read_vxrm(buf) do { asm volatile ("csrr %[BUF], vxrm" : [BUF] "=r" (buf)); } while (0);
 #define set_vxrm(val) do { asm volatile ("csrw vxrm, %0" :: "rK"(val)); } while (0);
 
 #define vtype(golden_vtype, vlmul, vsew, vta, vma) (golden_vtype = vlmul << 0 | vsew << 3 | vta << 6 | vma << 7)
@@ -80,6 +81,15 @@ int test_case;
   printf("Checking vxsat #%d...\n", casenum);                                                                      \
   if (vxsat != golden_vxsat) {                                                                                     \
     printf("FAILED. Got vxsat = %lx, expected vxsat = %lx.\n", vxsat, golden_vxsat);                               \
+    num_failed++;                                                                                                  \
+    return;                                                                                                        \
+  }                                                                                                                \
+  printf("PASSED.\n");
+
+#define check_vxrm(casenum, vxrm, golden_vxrm)                                                                     \
+  printf("Checking vxrm #%d...\n", casenum);                                                                       \
+  if (vxrm != golden_vxrm) {                                                                                       \
+    printf("FAILED. Got vxrm = %lx, expected vxrm = %lx.\n", vxrm, golden_vxrm);                                   \
     num_failed++;                                                                                                  \
     return;                                                                                                        \
   }                                                                                                                \

--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -5,7 +5,11 @@
 # Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
 #         Basile Bougenot <bbougenot@student.ethz.ch>
 
-rv64uv_sc_tests = vadd \
+rv64uv_sc_tests = vaadd \
+                  vaaddu\
+                  vsadd \
+                  vsaddu \
+                  vadd \
                   vsub \
                   vrsub \
                   vwaddu \

--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -7,8 +7,6 @@
 
 rv64uv_sc_tests = vaadd \
                   vaaddu\
-                  vsadd \
-                  vsaddu \
                   vasub\
                   vasubu\
                   vssubu\

--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -11,7 +11,6 @@ rv64uv_sc_tests = vaadd \
                   vsaddu \
                   vasub\
                   vasubu\
-                  vssub\
                   vssubu\
                   vadd \
                   vsub \

--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -9,6 +9,10 @@ rv64uv_sc_tests = vaadd \
                   vaaddu\
                   vsadd \
                   vsaddu \
+                  vasub\
+                  vasubu\
+                  vssub\
+                  vssubu\
                   vadd \
                   vsub \
                   vrsub \

--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -141,7 +141,9 @@ rv64uv_sc_tests = vaadd \
                   vsuxei \
                   vsetivli \
                   misa_v \
-                  mstatus_vs
+                  mstatus_vs \
+                  vxsat \
+                  vxrm
 
 #rv64uv_sc_tests = vaadd vaaddu vadc vasub vasubu vcompress vfclass vfdiv vfirst vfrdiv vfsqrt vid viota vl vlff vl_nocheck vlx vmsbf vmsif vmsof vpopc_m vrgather vsadd vsaddu vsetvl vsetivli vsetvli vsmul vssra vssrl vssub vssubu vsux vsx
 

--- a/apps/riscv-tests/isa/rv64uv/vaadd.c
+++ b/apps/riscv-tests/isa/rv64uv/vaadd.c
@@ -12,7 +12,7 @@ void TEST_CASE1(void) {
   VLOAD_8(v1, 1, -2, -3, 4);
   VLOAD_8(v2, 1, 2, -3, 4);
   __asm__ volatile("vaadd.vv v3, v1, v2" ::);
-  VEC_CMP_8(1, v3, 1, 0, -3, 4);
+  VCMP_U8(1, v3, 1, 0, -3, 4);
 }
 
 void TEST_CASE2(void) {
@@ -20,9 +20,9 @@ void TEST_CASE2(void) {
   VLOAD_8(v1, 1, -2, -3, 4);
   VLOAD_8(v2, 1, 2, -3, 4);
   VLOAD_8(v0, 0xA, 0x0, 0x0, 0x0);
-  CLEAR(v3);
+  VCLEAR(v3);
   __asm__ volatile("vaadd.vv v3, v1, v2, v0.t" ::);
-  VEC_CMP_8(2, v3, 0, 0, 0, 4);
+  VCMP_U8(2, v3, 0, 0, 0, 4);
 }
 
 void TEST_CASE3(void) {
@@ -30,7 +30,7 @@ void TEST_CASE3(void) {
   VLOAD_32(v1, 1, -2, 3, -4);
   const uint32_t scalar = 5;
   __asm__ volatile("vaadd.vx v3, v1, %[A]" ::[A] "r"(scalar));
-  VEC_CMP_32(3, v3, 3, 2, 4, 1);
+  VCMP_U32(3, v3, 3, 2, 4, 1);
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
@@ -39,9 +39,9 @@ void TEST_CASE4(void) {
   VLOAD_32(v1, 1, -2, 3, -4);
   const uint32_t scalar = 5;
   VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
-  CLEAR(v3);
+  VCLEAR(v3);
   __asm__ volatile("vaadd.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
-  VEC_CMP_32(4, v3, 0, 2, 0, 1);
+  VCMP_U32(4, v3, 0, 2, 0, 1);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vaadd.c
+++ b/apps/riscv-tests/isa/rv64uv/vaadd.c
@@ -8,40 +8,44 @@
 #include "vector_macros.h"
 
 void TEST_CASE1(void) {
+  set_vxrm(0); // setting vxrm to rnu rounding mode
   VSET(4, e8, m1);
   VLOAD_8(v1, 1, -2, -3, 4);
-  VLOAD_8(v2, 1, 2, -3, 4);
+  VLOAD_8(v2, 1, 2, -3, 3);
   __asm__ volatile("vaadd.vv v3, v1, v2" ::);
   VCMP_U8(1, v3, 1, 0, -3, 4);
 }
 
 void TEST_CASE2(void) {
+  set_vxrm(1); // setting vxrm to rne rounding mode
   VSET(4, e8, m1);
   VLOAD_8(v1, 1, -2, -3, 4);
-  VLOAD_8(v2, 1, 2, -3, 4);
+  VLOAD_8(v2, 1, 9, -3, 5);
   VLOAD_8(v0, 0xA, 0x0, 0x0, 0x0);
   VCLEAR(v3);
   __asm__ volatile("vaadd.vv v3, v1, v2, v0.t" ::);
-  VCMP_U8(2, v3, 0, 0, 0, 4);
+  VCMP_U8(2, v3, 0, 4, 0, 4);
 }
 
 void TEST_CASE3(void) {
+  set_vxrm(2); // setting vxrm to rdn rounding mode
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, -2, 3, -4);
   const uint32_t scalar = 5;
   __asm__ volatile("vaadd.vx v3, v1, %[A]" ::[A] "r"(scalar));
-  VCMP_U32(3, v3, 3, 2, 4, 1);
+  VCMP_U32(3, v3, 3, 1, 4, 0);
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
 void TEST_CASE4(void) {
+  set_vxrm(3); // setting vxrm to rod rounding mode
   VSET(4, e32, m1);
-  VLOAD_32(v1, 1, -2, 3, -4);
+  VLOAD_32(v1, 1, 2, 3, 4);
   const uint32_t scalar = 5;
   VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
   VCLEAR(v3);
   __asm__ volatile("vaadd.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
-  VCMP_U32(4, v3, 0, 2, 0, 1);
+  VCMP_U32(4, v3, 0, 3, 0, 5);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vaaddu.c
+++ b/apps/riscv-tests/isa/rv64uv/vaaddu.c
@@ -8,40 +8,44 @@
 #include "vector_macros.h"
 
 void TEST_CASE1(void) {
+  set_vxrm(0); // setting vxrm to rnu rounding mode
   VSET(4, e8, m1);
-  VLOAD_8(v1, 1, 2, 3, 4);
-  VLOAD_8(v2, 1, 2, 3, 4);
+  VLOAD_8(v1, 1, 2, 3, 5);
+  VLOAD_8(v2, 1, 3, 8, 4);
   __asm__ volatile("vaaddu.vv v3, v1, v2" ::);
-  VCMP_U8(1, v3, 1, 2, 3, 4);
+  VCMP_U8(1, v3, 1, 3, 6, 5);
 }
 
 void TEST_CASE2(void) {
+  set_vxrm(1); // setting vxrm to rne rounding mode
   VSET(4, e8, m1);
-  VLOAD_8(v1, 1, 2, 3, 4);
-  VLOAD_8(v2, 1, 2, 3, 4);
+  VLOAD_8(v1, 5, 8, 3, 7);
+  VLOAD_8(v2, 7, 5, 3, 5);
   VLOAD_8(v0, 0x0A, 0x00, 0x00, 0x00);
   VCLEAR(v3);
   __asm__ volatile("vaaddu.vv v3, v1, v2, v0.t" ::);
-  VCMP_U8(2, v3, 0, 2, 0, 4);
+  VCMP_U8(2, v3, 0, 6, 0, 6);
 }
 
 void TEST_CASE3(void) {
+  set_vxrm(2); // setting vxrm to rdn rounding mode
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, 2, 3, 4);
   const uint32_t scalar = 5;
   __asm__ volatile("vaaddu.vx v3, v1, %[A]" ::[A] "r"(scalar));
-  VCMP_U32(3, v3, 3, 4, 4, 5);
+  VCMP_U32(3, v3, 3, 3, 4, 4);
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
 void TEST_CASE4(void) {
+  set_vxrm(3); // setting vxrm to rod rounding mode
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, 2, 3, 4);
   const uint32_t scalar = 5;
   VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
   VCLEAR(v3);
   __asm__ volatile("vaaddu.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
-  VCMP_U32(4, v3, 0, 4, 0, 5);
+  VCMP_U32(4, v3, 0, 3, 0, 5);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vaaddu.c
+++ b/apps/riscv-tests/isa/rv64uv/vaaddu.c
@@ -12,7 +12,7 @@ void TEST_CASE1(void) {
   VLOAD_8(v1, 1, 2, 3, 4);
   VLOAD_8(v2, 1, 2, 3, 4);
   __asm__ volatile("vaaddu.vv v3, v1, v2" ::);
-  VEC_CMP_8(1, v3, 1, 2, 3, 4);
+  VCMP_U8(1, v3, 1, 2, 3, 4);
 }
 
 void TEST_CASE2(void) {
@@ -20,28 +20,28 @@ void TEST_CASE2(void) {
   VLOAD_8(v1, 1, 2, 3, 4);
   VLOAD_8(v2, 1, 2, 3, 4);
   VLOAD_8(v0, 0x0A, 0x00, 0x00, 0x00);
-  CLEAR(v3);
+  VCLEAR(v3);
   __asm__ volatile("vaaddu.vv v3, v1, v2, v0.t" ::);
-  VEC_CMP_8(2, v3, 0, 2, 0, 4);
+  VCMP_U8(2, v3, 0, 2, 0, 4);
 }
 
 void TEST_CASE3(void) {
   VSET(4, e32, m1);
-  VLOAD_U32(v1, 1, 2, 3, 4);
+  VLOAD_32(v1, 1, 2, 3, 4);
   const uint32_t scalar = 5;
   __asm__ volatile("vaaddu.vx v3, v1, %[A]" ::[A] "r"(scalar));
-  VEC_CMP_U32(3, v3, 3, 4, 4, 5);
+  VCMP_U32(3, v3, 3, 4, 4, 5);
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
 void TEST_CASE4(void) {
   VSET(4, e32, m1);
-  VLOAD_U32(v1, 1, 2, 3, 4);
+  VLOAD_32(v1, 1, 2, 3, 4);
   const uint32_t scalar = 5;
-  VLOAD_U32(v0, 0xA, 0x0, 0x0, 0x0);
-  CLEAR(v3);
+  VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
+  VCLEAR(v3);
   __asm__ volatile("vaaddu.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
-  VEC_CMP_U32(4, v3, 0, 4, 0, 5);
+  VCMP_U32(4, v3, 0, 4, 0, 5);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vasub.c
+++ b/apps/riscv-tests/isa/rv64uv/vasub.c
@@ -12,7 +12,7 @@ void TEST_CASE1(void) {
   VLOAD_32(v1, 5, 10, 15, 20);
   VLOAD_32(v2, -1, 2, -3, 4);
   __asm__ volatile("vasub.vv v3, v1, v2" ::);
-  VEC_CMP_32(1, v3, 3, 4, 9, 8);
+  VCMP_I32(1, v3, 3, 4, 9, 8);
 }
 
 void TEST_CASE2(void) {
@@ -20,27 +20,27 @@ void TEST_CASE2(void) {
   VLOAD_32(v1, 5, 10, 15, 20);
   VLOAD_32(v2, 1, 2, 3, -4);
   VLOAD_32(v0, 10, 0, 0, 0);
-  CLEAR(v3);
+  VCLEAR(v3);
   __asm__ volatile("vasub.vv v3, v1, v2, v0.t" ::);
-  VEC_CMP_32(2, v3, 0, 4, 0, 12);
+  VCMP_I32(2, v3, 0, 4, 0, 12);
 }
 
 void TEST_CASE3(void) {
   VSET(4, e32, m1);
-  VLOAD_U32(v1, 5, 10, 15, 20);
+  VLOAD_32(v1, 5, 10, 15, 20);
   const uint64_t scalar = -5;
   __asm__ volatile("vasub.vx v3, v1, %[A]" ::[A] "r"(scalar));
-  VEC_CMP_U32(3, v3, 5, 8, 10, 13);
+  VCMP_I32(3, v3, 5, 8, 10, 13);
 }
 
 void TEST_CASE4(void) {
   VSET(4, e32, m1);
-  VLOAD_U32(v1, 5, 10, 15, 20);
+  VLOAD_32(v1, 5, 10, 15, 20);
   const uint64_t scalar = -5;
-  VLOAD_U32(v0, 10, 0, 0, 0);
-  CLEAR(v3);
+  VLOAD_32(v0, 10, 0, 0, 0);
+  VCLEAR(v3);
   __asm__ volatile("vasub.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
-  VEC_CMP_U32(4, v3, 0, 8, 0, 13);
+  VCMP_I32(4, v3, 0, 8, 0, 13);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vasubu.c
+++ b/apps/riscv-tests/isa/rv64uv/vasubu.c
@@ -9,38 +9,38 @@
 
 void TEST_CASE1(void) {
   VSET(4, e32, m1);
-  VLOAD_U32(v1, 5, 10, 15, 20);
-  VLOAD_U32(v2, 1, 2, 3, 4);
+  VLOAD_32(v1, 5, 10, 15, 20);
+  VLOAD_32(v2, 1, 2, 3, 4);
   __asm__ volatile("vasubu.vv v3, v1, v2" ::);
-  VEC_CMP_U32(1, v3, 2, 4, 6, 8);
+  VCMP_U32(1, v3, 2, 4, 6, 8);
 }
 
 void TEST_CASE2(void) {
   VSET(4, e32, m1);
-  VLOAD_U32(v1, 5, 10, 15, 20);
-  VLOAD_U32(v2, 1, 2, 3, 4);
-  VLOAD_U32(v0, 10, 0, 0, 0);
-  CLEAR(v3);
+  VLOAD_32(v1, 5, 10, 15, 20);
+  VLOAD_32(v2, 1, 2, 3, 4);
+  VLOAD_32(v0, 10, 0, 0, 0);
+  VCLEAR(v3);
   __asm__ volatile("vasubu.vv v3, v1, v2, v0.t" ::);
-  VEC_CMP_U32(2, v3, 0, 4, 0, 8);
+  VCMP_U32(2, v3, 0, 4, 0, 8);
 }
 
 void TEST_CASE3(void) {
   VSET(4, e32, m1);
-  VLOAD_U32(v1, 5, 10, 15, 20);
+  VLOAD_32(v1, 5, 10, 15, 20);
   const uint64_t scalar = 5;
   __asm__ volatile("vasubu.vx v3, v1, %[A]" ::[A] "r"(scalar));
-  VEC_CMP_U32(3, v3, 0, 3, 5, 8);
+  VCMP_U32(3, v3, 0, 3, 5, 8);
 }
 
 void TEST_CASE4(void) {
   VSET(4, e32, m1);
-  VLOAD_U32(v1, 5, 10, 15, 20);
+  VLOAD_32(v1, 5, 10, 15, 20);
   const uint64_t scalar = 5;
-  VLOAD_U32(v0, 10, 0, 0, 0);
-  CLEAR(v3);
+  VLOAD_32(v0, 10, 0, 0, 0);
+  VCLEAR(v3);
   __asm__ volatile("vasubu.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
-  VEC_CMP_U32(4, v3, 0, 3, 0, 8);
+  VCMP_U32(4, v3, 0, 3, 0, 8);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vsadd.c
+++ b/apps/riscv-tests/isa/rv64uv/vsadd.c
@@ -8,14 +8,18 @@
 #include "vector_macros.h"
 
 void TEST_CASE1(void) {
+  uint64_t vxsat;
   VSET(4, e8, m1);
   VLOAD_8(v1, -80, 2, 100, 4);
   VLOAD_8(v2, -90, 2, 50, 4);
   __asm__ volatile("vsadd.vv v3, v1, v2" ::);
   VCMP_U8(1, v3, 0x80, 4, 127, 8);
+  read_vxsat(vxsat)
+  check_vxsat(1, vxsat, 1);
 }
 
 void TEST_CASE2(void) {
+  uint64_t vxsat;
   VSET(4, e8, m1);
   VLOAD_8(v1, -80, 2, 100, 4);
   VLOAD_8(v2, -90, 2, 50, 4);
@@ -23,35 +27,47 @@ void TEST_CASE2(void) {
   VCLEAR(v3);
   __asm__ volatile("vsadd.vv v3, v1, v2, v0.t" ::);
   VCMP_U8(2, v3, 0, 4, 0, 8);
+  read_vxsat(vxsat)
+  check_vxsat(2, vxsat, 0);
 }
 
 void TEST_CASE3(void) {
+  uint64_t vxsat;
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, 0x7FFFFFFB, 3, 4);
   __asm__ volatile("vsadd.vi v3, v1, 5" ::);
   VCMP_U32(3, v3, 6, 0x7FFFFFFF, 8, 9);
+  read_vxsat(vxsat)
+  check_vxsat(3, vxsat, 0);
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
 void TEST_CASE4(void) {
+  uint64_t vxsat;
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, 2, 0xFFFFFFFD, 0x7FFFFFFC);
   VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
   VCLEAR(v3);
   __asm__ volatile("vsadd.vi v3, v1, 5, v0.t" ::);
   VCMP_U32(4, v3, 0, 7, 0, 0x7FFFFFFF);
+  read_vxsat(vxsat)
+  check_vxsat(4, vxsat, 1);
 }
 
 void TEST_CASE5(void) {
+  uint64_t vxsat;
   VSET(4, e32, m1);
   VLOAD_32(v1, 0x7FFFFFFD, 2, 3, 4);
   const uint32_t scalar = 5;
   __asm__ volatile("vsadd.vx v3, v1, %[A]" ::[A] "r"(scalar));
   VCMP_U32(5, v3, 0x7FFFFFFF, 7, 8, 9);
+  read_vxsat(vxsat)
+  check_vxsat(5, vxsat, 1);
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
 void TEST_CASE6(void) {
+  uint64_t vxsat;
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, 0x7ffffffC, 3, 4);
   const uint32_t scalar = 5;
@@ -59,6 +75,8 @@ void TEST_CASE6(void) {
   VCLEAR(v3);
   __asm__ volatile("vsadd.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
   VCMP_U32(6, v3, 0, 0x7FFFFFFF, 0, 9);
+  read_vxsat(vxsat)
+  check_vxsat(6, vxsat, 1);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vsadd.c
+++ b/apps/riscv-tests/isa/rv64uv/vsadd.c
@@ -14,7 +14,7 @@ void TEST_CASE1(void) {
   VLOAD_8(v2, -90, 2, 50, 4);
   __asm__ volatile("vsadd.vv v3, v1, v2" ::);
   VCMP_U8(1, v3, 0x80, 4, 127, 8);
-  read_vxsat(vxsat)
+  read_vxsat(vxsat);
   check_vxsat(1, vxsat, 1);
 }
 
@@ -27,7 +27,7 @@ void TEST_CASE2(void) {
   VCLEAR(v3);
   __asm__ volatile("vsadd.vv v3, v1, v2, v0.t" ::);
   VCMP_U8(2, v3, 0, 4, 0, 8);
-  read_vxsat(vxsat)
+  read_vxsat(vxsat);
   check_vxsat(2, vxsat, 0);
 }
 
@@ -37,8 +37,8 @@ void TEST_CASE3(void) {
   VLOAD_32(v1, 1, 0x7FFFFFFB, 3, 4);
   __asm__ volatile("vsadd.vi v3, v1, 5" ::);
   VCMP_U32(3, v3, 6, 0x7FFFFFFF, 8, 9);
-  read_vxsat(vxsat)
-  check_vxsat(3, vxsat, 0);
+  read_vxsat(vxsat);
+  check_vxsat(3, vxsat, 1);
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
@@ -50,7 +50,7 @@ void TEST_CASE4(void) {
   VCLEAR(v3);
   __asm__ volatile("vsadd.vi v3, v1, 5, v0.t" ::);
   VCMP_U32(4, v3, 0, 7, 0, 0x7FFFFFFF);
-  read_vxsat(vxsat)
+  read_vxsat(vxsat);
   check_vxsat(4, vxsat, 1);
 }
 
@@ -61,7 +61,7 @@ void TEST_CASE5(void) {
   const uint32_t scalar = 5;
   __asm__ volatile("vsadd.vx v3, v1, %[A]" ::[A] "r"(scalar));
   VCMP_U32(5, v3, 0x7FFFFFFF, 7, 8, 9);
-  read_vxsat(vxsat)
+  read_vxsat(vxsat);
   check_vxsat(5, vxsat, 1);
 }
 
@@ -75,7 +75,7 @@ void TEST_CASE6(void) {
   VCLEAR(v3);
   __asm__ volatile("vsadd.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
   VCMP_U32(6, v3, 0, 0x7FFFFFFF, 0, 9);
-  read_vxsat(vxsat)
+  read_vxsat(vxsat);
   check_vxsat(6, vxsat, 1);
 }
 

--- a/apps/riscv-tests/isa/rv64uv/vsadd.c
+++ b/apps/riscv-tests/isa/rv64uv/vsadd.c
@@ -12,7 +12,7 @@ void TEST_CASE1(void) {
   VLOAD_8(v1, -80, 2, 100, 4);
   VLOAD_8(v2, -90, 2, 50, 4);
   __asm__ volatile("vsadd.vv v3, v1, v2" ::);
-  VEC_CMP_8(1, v3, 0x80, 4, 127, 8);
+  VCMP_U8(1, v3, 0x80, 4, 127, 8);
 }
 
 void TEST_CASE2(void) {
@@ -20,16 +20,16 @@ void TEST_CASE2(void) {
   VLOAD_8(v1, -80, 2, 100, 4);
   VLOAD_8(v2, -90, 2, 50, 4);
   VLOAD_8(v0, 0xA, 0x0, 0x0, 0x0);
-  CLEAR(v3);
+  VCLEAR(v3);
   __asm__ volatile("vsadd.vv v3, v1, v2, v0.t" ::);
-  VEC_CMP_8(2, v3, 0, 4, 0, 8);
+  VCMP_U8(2, v3, 0, 4, 0, 8);
 }
 
 void TEST_CASE3(void) {
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, 0x7FFFFFFB, 3, 4);
   __asm__ volatile("vsadd.vi v3, v1, 5" ::);
-  VEC_CMP_32(3, v3, 6, 0x7FFFFFFF, 8, 9);
+  VCMP_U32(3, v3, 6, 0x7FFFFFFF, 8, 9);
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
@@ -37,9 +37,9 @@ void TEST_CASE4(void) {
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, 2, 0xFFFFFFFD, 0x7FFFFFFC);
   VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
-  CLEAR(v3);
+  VCLEAR(v3);
   __asm__ volatile("vsadd.vi v3, v1, 5, v0.t" ::);
-  VEC_CMP_32(4, v3, 0, 7, 0, 0x7FFFFFFF);
+  VCMP_U32(4, v3, 0, 7, 0, 0x7FFFFFFF);
 }
 
 void TEST_CASE5(void) {
@@ -47,7 +47,7 @@ void TEST_CASE5(void) {
   VLOAD_32(v1, 0x7FFFFFFD, 2, 3, 4);
   const uint32_t scalar = 5;
   __asm__ volatile("vsadd.vx v3, v1, %[A]" ::[A] "r"(scalar));
-  VEC_CMP_32(5, v3, 0x7FFFFFFF, 7, 8, 9);
+  VCMP_U32(5, v3, 0x7FFFFFFF, 7, 8, 9);
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
@@ -56,9 +56,9 @@ void TEST_CASE6(void) {
   VLOAD_32(v1, 1, 0x7ffffffC, 3, 4);
   const uint32_t scalar = 5;
   VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
-  CLEAR(v3);
+  VCLEAR(v3);
   __asm__ volatile("vsadd.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
-  VEC_CMP_32(6, v3, 0, 0x7FFFFFFF, 0, 9);
+  VCMP_U32(6, v3, 0, 0x7FFFFFFF, 0, 9);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vsaddu.c
+++ b/apps/riscv-tests/isa/rv64uv/vsaddu.c
@@ -7,58 +7,90 @@
 
 #include "vector_macros.h"
 
+
 void TEST_CASE1(void) {
+  uint64_t vxsat;
   VSET(4, e8, m1);
   VLOAD_8(v1, 133, 2, 220, 4);
   VLOAD_8(v2, 133, 2, 50, 4);
   __asm__ volatile("vsaddu.vv v3, v1, v2" ::);
-  VEC_CMP_8(1, v3, 255, 4, 255, 8);
+  VCMP_U8(1, v3, 255, 4, 255, 8);
+  read_vxsat(vxsat)
+  check_vxsat(1, vxsat, 1);
 }
 
 void TEST_CASE2(void) {
+  uint64_t vxsat;
   VSET(4, e8, m1);
   VLOAD_8(v1, 1, 2, 3, 154);
   VLOAD_8(v2, 1, 2, 3, 124);
   VLOAD_8(v0, 0xA, 0x0, 0x0, 0x0);
-  CLEAR(v3);
+  VCLEAR(v3);
   __asm__ volatile("vsaddu.vv v3, v1, v2, v0.t" ::);
-  VEC_CMP_8(2, v3, 0, 4, 0, 255);
+  VCMP_U8(2, v3, 0, 4, 0, 255);
+  read_vxsat(vxsat);
+  check_vxsat(2, vxsat, 1);
 }
 
 void TEST_CASE3(void) {
+  uint64_t vxsat;
   VSET(4, e32, m1);
-  VLOAD_U32(v1, 1, 0xFFFFFFFB, 3, 4);
+  VLOAD_32(v1, 1, 0xFFFFFFFB, 3, 4);
   __asm__ volatile("vsaddu.vi v3, v1, 5" ::);
-  VEC_CMP_U32(3, v3, 6, 0xFFFFFFFF, 8, 9);
+  VCMP_U32(3, v3, 6, 0xFFFFFFFF, 8, 9);
+  read_vxsat(vxsat);
+  check_vxsat(3, vxsat, 1);
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
 void TEST_CASE4(void) {
+  uint64_t vxsat;
   VSET(4, e32, m1);
-  VLOAD_U32(v1, 1, 2, 0xFFFFFFFD, 0xFFFFFFFC);
+  VLOAD_32(v1, 1, 2, 0xFFFFFFFD, 0xFFFFFFFC);
   VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
-  CLEAR(v3);
+  VCLEAR(v3);
   __asm__ volatile("vsaddu.vi v3, v1, 5, v0.t" ::);
-  VEC_CMP_U32(4, v3, 0, 7, 0, 0xFFFFFFFF);
+  VCMP_U32(4, v3, 0, 7, 0, 0xFFFFFFFF);
+  read_vxsat(vxsat);
+  check_vxsat(4, vxsat, 1);
 }
 
 void TEST_CASE5(void) {
+  uint64_t vxsat;
   VSET(4, e32, m1);
   VLOAD_32(v1, 0xFFFFFFFD, 2, 3, 4);
   const uint32_t scalar = 5;
   __asm__ volatile("vsaddu.vx v3, v1, %[A]" ::[A] "r"(scalar));
-  VEC_CMP_32(5, v3, 0xFFFFFFFF, 7, 8, 9);
+  VCMP_U32(5, v3, 0xFFFFFFFF, 7, 8, 9);
+  read_vxsat(vxsat);
+  check_vxsat(5, vxsat, 1);
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
 void TEST_CASE6(void) {
+  uint64_t vxsat;
   VSET(4, e32, m1);
-  VLOAD_U32(v1, 1, 0xfffffffC, 3, 4);
+  VLOAD_32(v1, 1, 0xfffffffC, 3, 4);
   const uint32_t scalar = 5;
-  VLOAD_U32(v0, 0xA, 0x0, 0x0, 0x0);
-  CLEAR(v3);
+  VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
+  VCLEAR(v3);
   __asm__ volatile("vsaddu.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
-  VEC_CMP_U32(6, v3, 0, 0xFFFFFFFF, 0, 9);
+  VCMP_U32(6, v3, 0, 0xFFFFFFFF, 0, 9);
+  read_vxsat(vxsat);
+  check_vxsat(6, vxsat, 1);
+}
+
+// Dont use VCLEAR here, it results in a glitch where are values are off by 1
+void TEST_CASE7(void) {
+  uint64_t vxsat;
+  VSET(4, e32, m1);
+  VLOAD_32(v1, 1, 0x0000FFFF, 3, 4);
+  VLOAD_32(v2, 0xA, 0xFFFF0000, 0x0, 0x0);
+  VCLEAR(v3);
+  __asm__ volatile("vsaddu.vv v3, v1, v2" ::);
+  VCMP_U32(7, v3, 0xB, 0xFFFFFFFF, 3, 4);
+  read_vxsat(vxsat);
+  check_vxsat(7, vxsat, 0);
 }
 
 int main(void) {
@@ -71,5 +103,6 @@ int main(void) {
   TEST_CASE4();
   TEST_CASE5();
   TEST_CASE6();
+  TEST_CASE7();
   EXIT_CHECK();
 }

--- a/apps/riscv-tests/isa/rv64uv/vsaddu.c
+++ b/apps/riscv-tests/isa/rv64uv/vsaddu.c
@@ -7,7 +7,6 @@
 
 #include "vector_macros.h"
 
-
 void TEST_CASE1(void) {
   uint64_t vxsat;
   VSET(4, e8, m1);
@@ -80,7 +79,6 @@ void TEST_CASE6(void) {
   check_vxsat(6, vxsat, 1);
 }
 
-// Dont use VCLEAR here, it results in a glitch where are values are off by 1
 void TEST_CASE7(void) {
   uint64_t vxsat;
   VSET(4, e32, m1);

--- a/apps/riscv-tests/isa/rv64uv/vsaddu.c
+++ b/apps/riscv-tests/isa/rv64uv/vsaddu.c
@@ -14,7 +14,7 @@ void TEST_CASE1(void) {
   VLOAD_8(v2, 133, 2, 50, 4);
   __asm__ volatile("vsaddu.vv v3, v1, v2" ::);
   VCMP_U8(1, v3, 255, 4, 255, 8);
-  read_vxsat(vxsat)
+  read_vxsat(vxsat);
   check_vxsat(1, vxsat, 1);
 }
 

--- a/apps/riscv-tests/isa/rv64uv/vssub.c
+++ b/apps/riscv-tests/isa/rv64uv/vssub.c
@@ -8,14 +8,18 @@
 #include "vector_macros.h"
 
 void TEST_CASE1(void) {
+  uint64_t vxsat;
   VSET(4, e32, m1);
   VLOAD_32(v1, 0xfffffff0, 0x7FFFFFFC, 15, 20);
   VLOAD_32(v2, 0x7ffffff0, -500, 3, 25);
   __asm__ volatile("vssub.vv v3, v1, v2" ::);
   VCMP_U32(1, v3, 0x80000000, 0x7fffffff, 12, -5);
+  read_vxsat(vxsat)
+  check_vxsat(1, vxsat, 1);
 }
 
 void TEST_CASE2(void) {
+  uint64_t vxsat;
   VSET(4, e32, m1);
   VLOAD_32(v1, 0xfffffff0, 0x7FFFFFFC, 15, 20);
   VLOAD_32(v2, 0x7ffffff0, -500, 3, 25);
@@ -23,14 +27,19 @@ void TEST_CASE2(void) {
   VCLEAR(v3);
   __asm__ volatile("vssub.vv v3, v1, v2, v0.t" ::);
   VCMP_U32(1, v3, 0, 0x7fffffff, 0, -5);
+  read_vxsat(vxsat)
+  check_vxsat(2, vxsat, 1);
 }
 
 void TEST_CASE3(void) {
+  uint64_t vxsat;
   VSET(4, e32, m1);
   VLOAD_32(v1, 5, -2147483645, 15, 20);
   const int64_t scalar = 5;
   __asm__ volatile("vssub.vx v3, v1, %[A]" ::[A] "r"(scalar));
   VCMP_U32(3, v3, 0, 0x80000000, 10, 15);
+  read_vxsat(vxsat)
+  check_vxsat(3, vxsat, 1);
 }
 
 void TEST_CASE4(void) {

--- a/apps/riscv-tests/isa/rv64uv/vssub.c
+++ b/apps/riscv-tests/isa/rv64uv/vssub.c
@@ -12,7 +12,7 @@ void TEST_CASE1(void) {
   VLOAD_32(v1, 0xfffffff0, 0x7FFFFFFC, 15, 20);
   VLOAD_32(v2, 0x7ffffff0, -500, 3, 25);
   __asm__ volatile("vssub.vv v3, v1, v2" ::);
-  VEC_CMP_32(1, v3, 0x80000000, 0x7fffffff, 12, -5);
+  VCMP_U32(1, v3, 0x80000000, 0x7fffffff, 12, -5);
 }
 
 void TEST_CASE2(void) {
@@ -20,9 +20,9 @@ void TEST_CASE2(void) {
   VLOAD_32(v1, 0xfffffff0, 0x7FFFFFFC, 15, 20);
   VLOAD_32(v2, 0x7ffffff0, -500, 3, 25);
   VLOAD_32(v0, 10, 0, 0, 0);
-  CLEAR(v3);
+  VCLEAR(v3);
   __asm__ volatile("vssub.vv v3, v1, v2, v0.t" ::);
-  VEC_CMP_32(1, v3, 0, 0x7fffffff, 0, -5);
+  VCMP_U32(1, v3, 0, 0x7fffffff, 0, -5);
 }
 
 void TEST_CASE3(void) {
@@ -30,7 +30,7 @@ void TEST_CASE3(void) {
   VLOAD_32(v1, 5, -2147483645, 15, 20);
   const int64_t scalar = 5;
   __asm__ volatile("vssub.vx v3, v1, %[A]" ::[A] "r"(scalar));
-  VEC_CMP_32(3, v3, 0, 0x80000000, 10, 15);
+  VCMP_U32(3, v3, 0, 0x80000000, 10, 15);
 }
 
 void TEST_CASE4(void) {
@@ -38,9 +38,9 @@ void TEST_CASE4(void) {
   VLOAD_32(v1, 5, -2147483645, 15, 20);
   const int64_t scalar = 5;
   VLOAD_32(v0, 10, 0, 0, 0);
-  CLEAR(v3);
+  VCLEAR(v3);
   __asm__ volatile("vssub.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
-  VEC_CMP_32(4, v3, 0, 0x80000000, 0, 15);
+  VCMP_U32(4, v3, 0, 0x80000000, 0, 15);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vssub.c
+++ b/apps/riscv-tests/isa/rv64uv/vssub.c
@@ -14,7 +14,7 @@ void TEST_CASE1(void) {
   VLOAD_32(v2, 0x7ffffff0, -500, 3, 25);
   __asm__ volatile("vssub.vv v3, v1, v2" ::);
   VCMP_U32(1, v3, 0x80000000, 0, 12, 0);
-  read_vxsat(vxsat)
+  read_vxsat(vxsat);
   check_vxsat(1, vxsat, 1);
 }
 
@@ -27,7 +27,7 @@ void TEST_CASE2(void) {
   VCLEAR(v3);
   __asm__ volatile("vssub.vv v3, v1, v2, v0.t" ::);
   VCMP_U32(1, v3, 0, 0, 0, 0);
-  read_vxsat(vxsat)
+  read_vxsat(vxsat);
   check_vxsat(2, vxsat, 1);
 }
 
@@ -38,7 +38,7 @@ void TEST_CASE3(void) {
   const int64_t scalar = 5;
   __asm__ volatile("vssub.vx v3, v1, %[A]" ::[A] "r"(scalar));
   VCMP_U32(3, v3, 0, 0x7FFFFFFE, 10, 15);
-  read_vxsat(vxsat)
+  read_vxsat(vxsat);
   check_vxsat(3, vxsat, 0);
 }
 

--- a/apps/riscv-tests/isa/rv64uv/vssub.c
+++ b/apps/riscv-tests/isa/rv64uv/vssub.c
@@ -13,7 +13,7 @@ void TEST_CASE1(void) {
   VLOAD_32(v1, 0xfffffff0, 0x7FFFFFFC, 15, 20);
   VLOAD_32(v2, 0x7ffffff0, -500, 3, 25);
   __asm__ volatile("vssub.vv v3, v1, v2" ::);
-  VCMP_U32(1, v3, 0x80000000, 0x7fffffff, 12, -5);
+  VCMP_U32(1, v3, 0x80000000, 0, 12, 0);
   read_vxsat(vxsat)
   check_vxsat(1, vxsat, 1);
 }
@@ -26,7 +26,7 @@ void TEST_CASE2(void) {
   VLOAD_32(v0, 10, 0, 0, 0);
   VCLEAR(v3);
   __asm__ volatile("vssub.vv v3, v1, v2, v0.t" ::);
-  VCMP_U32(1, v3, 0, 0x7fffffff, 0, -5);
+  VCMP_U32(1, v3, 0, 0, 0, 0);
   read_vxsat(vxsat)
   check_vxsat(2, vxsat, 1);
 }
@@ -37,9 +37,9 @@ void TEST_CASE3(void) {
   VLOAD_32(v1, 5, -2147483645, 15, 20);
   const int64_t scalar = 5;
   __asm__ volatile("vssub.vx v3, v1, %[A]" ::[A] "r"(scalar));
-  VCMP_U32(3, v3, 0, 0x80000000, 10, 15);
+  VCMP_U32(3, v3, 0, 0x7FFFFFFE, 10, 15);
   read_vxsat(vxsat)
-  check_vxsat(3, vxsat, 1);
+  check_vxsat(3, vxsat, 0);
 }
 
 void TEST_CASE4(void) {
@@ -49,7 +49,7 @@ void TEST_CASE4(void) {
   VLOAD_32(v0, 10, 0, 0, 0);
   VCLEAR(v3);
   __asm__ volatile("vssub.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
-  VCMP_U32(4, v3, 0, 0x80000000, 0, 15);
+  VCMP_U32(4, v3, 0, 0x7FFFFFFE, 0, 15);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vssubu.c
+++ b/apps/riscv-tests/isa/rv64uv/vssubu.c
@@ -9,38 +9,38 @@
 
 void TEST_CASE1(void) {
   VSET(4, e32, m1);
-  VLOAD_U32(v1, 5, 10, 15, 20);
-  VLOAD_U32(v2, 1, 2, 3, 25);
+  VLOAD_32(v1, 5, 10, 15, 20);
+  VLOAD_32(v2, 1, 2, 3, 25);
   __asm__ volatile("vssubu.vv v3, v1, v2" ::);
-  VEC_CMP_U32(1, v3, 4, 8, 12, 0);
+  VCMP_U32(1, v3, 4, 8, 12, 0);
 }
 
 void TEST_CASE2(void) {
   VSET(4, e32, m1);
-  VLOAD_U32(v1, 5, 10, 15, 20);
-  VLOAD_U32(v2, 1, 2, 3, 120);
-  VLOAD_U32(v0, 10, 0, 0, 0);
-  CLEAR(v3);
+  VLOAD_32(v1, 5, 10, 15, 20);
+  VLOAD_32(v2, 1, 2, 3, 120);
+  VLOAD_32(v0, 10, 0, 0, 0);
+  VCLEAR(v3);
   __asm__ volatile("vssubu.vv v3, v1, v2, v0.t" ::);
-  VEC_CMP_U32(2, v3, 0, 8, 0, 0);
+  VCMP_U32(2, v3, 0, 8, 0, 0);
 }
 
 void TEST_CASE3(void) {
   VSET(4, e32, m1);
-  VLOAD_U32(v1, 5, 1, 15, 20);
+  VLOAD_32(v1, 5, 1, 15, 20);
   const uint64_t scalar = 5;
   __asm__ volatile("vssubu.vx v3, v1, %[A]" ::[A] "r"(scalar));
-  VEC_CMP_U32(3, v3, 0, 0, 10, 15);
+  VCMP_U32(3, v3, 0, 0, 10, 15);
 }
 
 void TEST_CASE4(void) {
   VSET(4, e32, m1);
-  VLOAD_U32(v1, 5, 1, 15, 20);
+  VLOAD_32(v1, 5, 1, 15, 20);
   const uint64_t scalar = 5;
-  VLOAD_U32(v0, 10, 0, 0, 0);
-  CLEAR(v3);
+  VLOAD_32(v0, 10, 0, 0, 0);
+  VCLEAR(v3);
   __asm__ volatile("vssubu.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
-  VEC_CMP_U32(4, v3, 0, 0, 0, 15);
+  VCMP_U32(4, v3, 0, 0, 0, 15);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vxrm.c
+++ b/apps/riscv-tests/isa/rv64uv/vxrm.c
@@ -8,7 +8,7 @@
 #include "vector_macros.h"
 
 void TEST_CASE1(void) {
-  uint64_t vxrm;
+  uint64_t vxrm = -1;
   set_vxrm(0); // setting vxrm to rnu rounding mode
   VSET(4, e8, m1);
   VLOAD_8(v1, 1, -2, -3, 4);
@@ -20,7 +20,7 @@ void TEST_CASE1(void) {
 }
 
 void TEST_CASE2(void) {
-  uint64_t vxrm;
+  uint64_t vxrm = -1;
   set_vxrm(1); // setting vxrm to rne rounding mode
   VSET(4, e8, m1);
   VLOAD_8(v1, 1, -2, -3, 4);
@@ -34,7 +34,7 @@ void TEST_CASE2(void) {
 }
 
 void TEST_CASE3(void) {
-  uint64_t vxrm;
+  uint64_t vxrm = -1;
   set_vxrm(2); // setting vxrm to rdn rounding mode
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, -2, 3, -4);
@@ -47,7 +47,7 @@ void TEST_CASE3(void) {
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
 void TEST_CASE4(void) {
-  uint64_t vxrm;
+  uint64_t vxrm = -1;
   set_vxrm(3); // setting vxrm to rod rounding mode
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, 2, 3, 4);
@@ -62,7 +62,7 @@ void TEST_CASE4(void) {
 
 
 void TEST_CASE5(void) {
-  uint64_t vxrm;
+  uint64_t vxrm = -1;
   set_vxrm(0); // setting vxrm to rnu rounding mode
   VSET(4, e8, m1);
   VLOAD_8(v1, 1, 2, 3, 5);
@@ -74,7 +74,7 @@ void TEST_CASE5(void) {
 }
 
 void TEST_CASE6(void) {
-  uint64_t vxrm;
+  uint64_t vxrm = -1;
   set_vxrm(1); // setting vxrm to rne rounding mode
   VSET(4, e8, m1);
   VLOAD_8(v1, 5, 8, 3, 7);
@@ -88,7 +88,7 @@ void TEST_CASE6(void) {
 }
 
 void TEST_CASE7(void) {
-  uint64_t vxrm;
+  uint64_t vxrm = -1;
   set_vxrm(2); // setting vxrm to rdn rounding mode
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, 2, 3, 4);
@@ -101,7 +101,7 @@ void TEST_CASE7(void) {
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
 void TEST_CASE8(void) {
-  uint64_t vxrm;
+  uint64_t vxrm = -1;
   set_vxrm(3); // setting vxrm to rod rounding mode
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, 2, 3, 4);

--- a/apps/riscv-tests/isa/rv64uv/vxrm.c
+++ b/apps/riscv-tests/isa/rv64uv/vxrm.c
@@ -16,7 +16,8 @@ void TEST_CASE1(void) {
   __asm__ volatile("vaadd.vv v3, v1, v2" ::);
   VCMP_U8(1, v3, 1, 0, -3, 4);
   read_vxrm(vxrm);
-  check_vxrm(1, vxrm >> 2, 0);// The upper bits, vxrm[XLEN-1:2], should be written as zeros
+  check_vxrm(1, vxrm >> 2,
+             0); // The upper bits, vxrm[XLEN-1:2], should be written as zeros
 }
 
 void TEST_CASE2(void) {
@@ -30,7 +31,8 @@ void TEST_CASE2(void) {
   __asm__ volatile("vaadd.vv v3, v1, v2, v0.t" ::);
   VCMP_U8(2, v3, 0, 4, 0, 4);
   read_vxrm(vxrm);
-  check_vxrm(2, vxrm >> 2, 0);// The upper bits, vxrm[XLEN-1:2], should be written as zeros
+  check_vxrm(2, vxrm >> 2,
+             0); // The upper bits, vxrm[XLEN-1:2], should be written as zeros
 }
 
 void TEST_CASE3(void) {
@@ -42,7 +44,8 @@ void TEST_CASE3(void) {
   __asm__ volatile("vaadd.vx v3, v1, %[A]" ::[A] "r"(scalar));
   VCMP_U32(3, v3, 3, 1, 4, 0);
   read_vxrm(vxrm);
-  check_vxrm(3, vxrm >> 2, 0);// The upper bits, vxrm[XLEN-1:2], should be written as zeros
+  check_vxrm(3, vxrm >> 2,
+             0); // The upper bits, vxrm[XLEN-1:2], should be written as zeros
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
@@ -57,9 +60,9 @@ void TEST_CASE4(void) {
   __asm__ volatile("vaadd.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
   VCMP_U32(4, v3, 0, 3, 0, 5);
   read_vxrm(vxrm);
-  check_vxrm(4, vxrm >> 2, 0);// The upper bits, vxrm[XLEN-1:2], should be written as zeros
+  check_vxrm(4, vxrm >> 2,
+             0); // The upper bits, vxrm[XLEN-1:2], should be written as zeros
 }
-
 
 void TEST_CASE5(void) {
   uint64_t vxrm = -1;
@@ -70,7 +73,8 @@ void TEST_CASE5(void) {
   __asm__ volatile("vaaddu.vv v3, v1, v2" ::);
   VCMP_U8(5, v3, 1, 3, 6, 5);
   read_vxrm(vxrm);
-  check_vxrm(5, vxrm >> 2, 0);// The upper bits, vxrm[XLEN-1:2], should be written as zeros
+  check_vxrm(5, vxrm >> 2,
+             0); // The upper bits, vxrm[XLEN-1:2], should be written as zeros
 }
 
 void TEST_CASE6(void) {
@@ -84,7 +88,8 @@ void TEST_CASE6(void) {
   __asm__ volatile("vaaddu.vv v3, v1, v2, v0.t" ::);
   VCMP_U8(6, v3, 0, 6, 0, 6);
   read_vxrm(vxrm);
-  check_vxrm(6, vxrm >> 2, 0);// The upper bits, vxrm[XLEN-1:2], should be written as zeros
+  check_vxrm(6, vxrm >> 2,
+             0); // The upper bits, vxrm[XLEN-1:2], should be written as zeros
 }
 
 void TEST_CASE7(void) {
@@ -96,7 +101,8 @@ void TEST_CASE7(void) {
   __asm__ volatile("vaaddu.vx v3, v1, %[A]" ::[A] "r"(scalar));
   VCMP_U32(7, v3, 3, 3, 4, 4);
   read_vxrm(vxrm);
-  check_vxrm(7, vxrm >> 2, 0);// The upper bits, vxrm[XLEN-1:2], should be written as zeros
+  check_vxrm(7, vxrm >> 2,
+             0); // The upper bits, vxrm[XLEN-1:2], should be written as zeros
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
@@ -111,18 +117,19 @@ void TEST_CASE8(void) {
   __asm__ volatile("vaaddu.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
   VCMP_U32(8, v3, 0, 3, 0, 5);
   read_vxrm(vxrm);
-  check_vxrm(8, vxrm >> 2, 0);// The upper bits, vxrm[XLEN-1:2], should be written as zeros
+  check_vxrm(8, vxrm >> 2,
+             0); // The upper bits, vxrm[XLEN-1:2], should be written as zeros
 }
 
 int main(void) {
   INIT_CHECK();
   enable_vec();
-  //vaadd.vv based cases
+  // vaadd.vv based cases
   TEST_CASE1();
   TEST_CASE2();
   TEST_CASE3();
   TEST_CASE4();
-  //vaaddu.vv based cases
+  // vaaddu.vv based cases
   TEST_CASE5();
   TEST_CASE6();
   TEST_CASE7();

--- a/apps/riscv-tests/isa/rv64uv/vxrm.c
+++ b/apps/riscv-tests/isa/rv64uv/vxrm.c
@@ -1,0 +1,131 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
+//         Basile Bougenot <bbougenot@student.ethz.ch>
+
+#include "vector_macros.h"
+
+void TEST_CASE1(void) {
+  uint64_t vxrm;
+  set_vxrm(0); // setting vxrm to rnu rounding mode
+  VSET(4, e8, m1);
+  VLOAD_8(v1, 1, -2, -3, 4);
+  VLOAD_8(v2, 1, 2, -3, 3);
+  __asm__ volatile("vaadd.vv v3, v1, v2" ::);
+  VCMP_U8(1, v3, 1, 0, -3, 4);
+  read_vxrm(vxrm);
+  check_vxrm(1, vxrm >> 2, 0);// The upper bits, vxrm[XLEN-1:2], should be written as zeros
+}
+
+void TEST_CASE2(void) {
+  uint64_t vxrm;
+  set_vxrm(1); // setting vxrm to rne rounding mode
+  VSET(4, e8, m1);
+  VLOAD_8(v1, 1, -2, -3, 4);
+  VLOAD_8(v2, 1, 9, -3, 5);
+  VLOAD_8(v0, 0xA, 0x0, 0x0, 0x0);
+  VCLEAR(v3);
+  __asm__ volatile("vaadd.vv v3, v1, v2, v0.t" ::);
+  VCMP_U8(2, v3, 0, 4, 0, 4);
+  read_vxrm(vxrm);
+  check_vxrm(2, vxrm >> 2, 0);// The upper bits, vxrm[XLEN-1:2], should be written as zeros
+}
+
+void TEST_CASE3(void) {
+  uint64_t vxrm;
+  set_vxrm(2); // setting vxrm to rdn rounding mode
+  VSET(4, e32, m1);
+  VLOAD_32(v1, 1, -2, 3, -4);
+  const uint32_t scalar = 5;
+  __asm__ volatile("vaadd.vx v3, v1, %[A]" ::[A] "r"(scalar));
+  VCMP_U32(3, v3, 3, 1, 4, 0);
+  read_vxrm(vxrm);
+  check_vxrm(3, vxrm >> 2, 0);// The upper bits, vxrm[XLEN-1:2], should be written as zeros
+}
+
+// Dont use VCLEAR here, it results in a glitch where are values are off by 1
+void TEST_CASE4(void) {
+  uint64_t vxrm;
+  set_vxrm(3); // setting vxrm to rod rounding mode
+  VSET(4, e32, m1);
+  VLOAD_32(v1, 1, 2, 3, 4);
+  const uint32_t scalar = 5;
+  VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
+  VCLEAR(v3);
+  __asm__ volatile("vaadd.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
+  VCMP_U32(4, v3, 0, 3, 0, 5);
+  read_vxrm(vxrm);
+  check_vxrm(4, vxrm >> 2, 0);// The upper bits, vxrm[XLEN-1:2], should be written as zeros
+}
+
+
+void TEST_CASE5(void) {
+  uint64_t vxrm;
+  set_vxrm(0); // setting vxrm to rnu rounding mode
+  VSET(4, e8, m1);
+  VLOAD_8(v1, 1, 2, 3, 5);
+  VLOAD_8(v2, 1, 3, 8, 4);
+  __asm__ volatile("vaaddu.vv v3, v1, v2" ::);
+  VCMP_U8(5, v3, 1, 3, 6, 5);
+  read_vxrm(vxrm);
+  check_vxrm(5, vxrm >> 2, 0);// The upper bits, vxrm[XLEN-1:2], should be written as zeros
+}
+
+void TEST_CASE6(void) {
+  uint64_t vxrm;
+  set_vxrm(1); // setting vxrm to rne rounding mode
+  VSET(4, e8, m1);
+  VLOAD_8(v1, 5, 8, 3, 7);
+  VLOAD_8(v2, 7, 5, 3, 5);
+  VLOAD_8(v0, 0x0A, 0x00, 0x00, 0x00);
+  VCLEAR(v3);
+  __asm__ volatile("vaaddu.vv v3, v1, v2, v0.t" ::);
+  VCMP_U8(6, v3, 0, 6, 0, 6);
+  read_vxrm(vxrm);
+  check_vxrm(6, vxrm >> 2, 0);// The upper bits, vxrm[XLEN-1:2], should be written as zeros
+}
+
+void TEST_CASE7(void) {
+  uint64_t vxrm;
+  set_vxrm(2); // setting vxrm to rdn rounding mode
+  VSET(4, e32, m1);
+  VLOAD_32(v1, 1, 2, 3, 4);
+  const uint32_t scalar = 5;
+  __asm__ volatile("vaaddu.vx v3, v1, %[A]" ::[A] "r"(scalar));
+  VCMP_U32(7, v3, 3, 3, 4, 4);
+  read_vxrm(vxrm);
+  check_vxrm(7, vxrm >> 2, 0);// The upper bits, vxrm[XLEN-1:2], should be written as zeros
+}
+
+// Dont use VCLEAR here, it results in a glitch where are values are off by 1
+void TEST_CASE8(void) {
+  uint64_t vxrm;
+  set_vxrm(3); // setting vxrm to rod rounding mode
+  VSET(4, e32, m1);
+  VLOAD_32(v1, 1, 2, 3, 4);
+  const uint32_t scalar = 5;
+  VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
+  VCLEAR(v3);
+  __asm__ volatile("vaaddu.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
+  VCMP_U32(8, v3, 0, 3, 0, 5);
+  read_vxrm(vxrm);
+  check_vxrm(8, vxrm >> 2, 0);// The upper bits, vxrm[XLEN-1:2], should be written as zeros
+}
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+  //vaadd.vv based cases
+  TEST_CASE1();
+  TEST_CASE2();
+  TEST_CASE3();
+  TEST_CASE4();
+  //vaaddu.vv based cases
+  TEST_CASE5();
+  TEST_CASE6();
+  TEST_CASE7();
+  TEST_CASE8();
+  EXIT_CHECK();
+}

--- a/apps/riscv-tests/isa/rv64uv/vxsat.c
+++ b/apps/riscv-tests/isa/rv64uv/vxsat.c
@@ -1,0 +1,201 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
+//         Basile Bougenot <bbougenot@student.ethz.ch>
+
+#include "vector_macros.h"
+
+void TEST_CASE1(void) {
+  uint64_t vxsat;
+  VSET(4, e8, m1);
+  VLOAD_8(v1, -80, 2, 100, 4);
+  VLOAD_8(v2, -90, 2, 50, 4);
+  __asm__ volatile("vsadd.vv v3, v1, v2" ::);
+  VCMP_U8(1, v3, 0x80, 4, 127, 8);
+  read_vxsat(vxsat);
+  check_vxsat(1, vxsat, 1);
+  check_vxsat(1, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
+}
+
+void TEST_CASE2(void) {
+  uint64_t vxsat;
+  VSET(4, e8, m1);
+  VLOAD_8(v1, -80, 2, 100, 4);
+  VLOAD_8(v2, -90, 2, 50, 4);
+  VLOAD_8(v0, 0xA, 0x0, 0x0, 0x0);
+  VCLEAR(v3);
+  __asm__ volatile("vsadd.vv v3, v1, v2, v0.t" ::);
+  VCMP_U8(2, v3, 0, 4, 0, 8);
+  read_vxsat(vxsat);
+  check_vxsat(2, vxsat, 0);
+  check_vxsat(2, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
+}
+
+void TEST_CASE3(void) {
+  uint64_t vxsat;
+  VSET(4, e32, m1);
+  VLOAD_32(v1, 1, 0x7FFFFFFB, 3, 4);
+  __asm__ volatile("vsadd.vi v3, v1, 5" ::);
+  VCMP_U32(3, v3, 6, 0x7FFFFFFF, 8, 9);
+  read_vxsat(vxsat);
+  check_vxsat(3, vxsat, 1);
+  check_vxsat(3, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
+}
+
+// Dont use VCLEAR here, it results in a glitch where are values are off by 1
+void TEST_CASE4(void) {
+  uint64_t vxsat;
+  VSET(4, e32, m1);
+  VLOAD_32(v1, 1, 2, 0xFFFFFFFD, 0x7FFFFFFC);
+  VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
+  VCLEAR(v3);
+  __asm__ volatile("vsadd.vi v3, v1, 5, v0.t" ::);
+  VCMP_U32(4, v3, 0, 7, 0, 0x7FFFFFFF);
+  read_vxsat(vxsat);
+  check_vxsat(4, vxsat, 1);
+  check_vxsat(4, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
+}
+
+void TEST_CASE5(void) {
+  uint64_t vxsat;
+  VSET(4, e32, m1);
+  VLOAD_32(v1, 0x7FFFFFFD, 2, 3, 4);
+  const uint32_t scalar = 5;
+  __asm__ volatile("vsadd.vx v3, v1, %[A]" ::[A] "r"(scalar));
+  VCMP_U32(5, v3, 0x7FFFFFFF, 7, 8, 9);
+  read_vxsat(vxsat);
+  check_vxsat(5, vxsat, 1);
+  check_vxsat(5, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
+}
+
+// Dont use VCLEAR here, it results in a glitch where are values are off by 1
+void TEST_CASE6(void) {
+  uint64_t vxsat;
+  VSET(4, e32, m1);
+  VLOAD_32(v1, 1, 0x7ffffffC, 3, 4);
+  const uint32_t scalar = 5;
+  VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
+  VCLEAR(v3);
+  __asm__ volatile("vsadd.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
+  VCMP_U32(6, v3, 0, 0x7FFFFFFF, 0, 9);
+  read_vxsat(vxsat);
+  check_vxsat(6, vxsat, 1);
+  check_vxsat(6, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
+}
+
+
+void TEST_CASE7(void) {
+  uint64_t vxsat;
+  VSET(4, e8, m1);
+  VLOAD_8(v1, 133, 2, 220, 4);
+  VLOAD_8(v2, 133, 2, 50, 4);
+  __asm__ volatile("vsaddu.vv v3, v1, v2" ::);
+  VCMP_U8(7, v3, 255, 4, 255, 8);
+  read_vxsat(vxsat);
+  check_vxsat(7, vxsat, 1);
+  check_vxsat(7, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
+}
+
+void TEST_CASE8(void) {
+  uint64_t vxsat;
+  VSET(4, e8, m1);
+  VLOAD_8(v1, 1, 2, 3, 154);
+  VLOAD_8(v2, 1, 2, 3, 124);
+  VLOAD_8(v0, 0xA, 0x0, 0x0, 0x0);
+  VCLEAR(v3);
+  __asm__ volatile("vsaddu.vv v3, v1, v2, v0.t" ::);
+  VCMP_U8(8, v3, 0, 4, 0, 255);
+  read_vxsat(vxsat);
+  check_vxsat(8, vxsat, 1);
+  check_vxsat(8, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
+}
+
+void TEST_CASE9(void) {
+  uint64_t vxsat;
+  VSET(4, e32, m1);
+  VLOAD_32(v1, 1, 0xFFFFFFFB, 3, 4);
+  __asm__ volatile("vsaddu.vi v3, v1, 5" ::);
+  VCMP_U32(9, v3, 6, 0xFFFFFFFF, 8, 9);
+  read_vxsat(vxsat);
+  check_vxsat(9, vxsat, 1);
+  check_vxsat(9, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
+}
+
+// Dont use VCLEAR here, it results in a glitch where are values are off by 1
+void TEST_CASE10(void) {
+  uint64_t vxsat;
+  VSET(4, e32, m1);
+  VLOAD_32(v1, 1, 2, 0xFFFFFFFD, 0xFFFFFFFC);
+  VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
+  VCLEAR(v3);
+  __asm__ volatile("vsaddu.vi v3, v1, 5, v0.t" ::);
+  VCMP_U32(10, v3, 0, 7, 0, 0xFFFFFFFF);
+  read_vxsat(vxsat);
+  check_vxsat(10, vxsat, 1);
+  check_vxsat(10, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
+}
+
+void TEST_CASE11(void) {
+  uint64_t vxsat;
+  VSET(4, e32, m1);
+  VLOAD_32(v1, 0xFFFFFFFD, 2, 3, 4);
+  const uint32_t scalar = 5;
+  __asm__ volatile("vsaddu.vx v3, v1, %[A]" ::[A] "r"(scalar));
+  VCMP_U32(11, v3, 0xFFFFFFFF, 7, 8, 9);
+  read_vxsat(vxsat);
+  check_vxsat(11, vxsat, 1);
+  check_vxsat(11, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
+}
+
+// Dont use VCLEAR here, it results in a glitch where are values are off by 1
+void TEST_CASE12(void) {
+  uint64_t vxsat;
+  VSET(4, e32, m1);
+  VLOAD_32(v1, 1, 0xfffffffC, 3, 4);
+  const uint32_t scalar = 5;
+  VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
+  VCLEAR(v3);
+  __asm__ volatile("vsaddu.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
+  VCMP_U32(12, v3, 0, 0xFFFFFFFF, 0, 9);
+  read_vxsat(vxsat);
+  check_vxsat(12, vxsat, 1);
+  check_vxsat(12, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
+}
+
+void TEST_CASE13(void) {
+  uint64_t vxsat;
+  VSET(4, e32, m1);
+  VLOAD_32(v1, 1, 0x0000FFFF, 3, 4);
+  VLOAD_32(v2, 0xA, 0xFFFF0000, 0x0, 0x0);
+  VCLEAR(v3);
+  __asm__ volatile("vsaddu.vv v3, v1, v2" ::);
+  VCMP_U32(13, v3, 0xB, 0xFFFFFFFF, 3, 4);
+  read_vxsat(vxsat);
+  check_vxsat(13, vxsat, 0);
+  check_vxsat(13, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
+}
+
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+  enable_fp();
+  //vsadd.vv based cases
+  TEST_CASE1();
+  TEST_CASE2();
+  TEST_CASE3();
+  TEST_CASE4();
+  TEST_CASE5();
+  TEST_CASE6();
+  //vsaddu.vv based cases
+  TEST_CASE7();
+  TEST_CASE8();
+  TEST_CASE9();
+  TEST_CASE10();
+  TEST_CASE11();
+  TEST_CASE12();
+  TEST_CASE13();
+  EXIT_CHECK();
+}

--- a/apps/riscv-tests/isa/rv64uv/vxsat.c
+++ b/apps/riscv-tests/isa/rv64uv/vxsat.c
@@ -48,11 +48,11 @@ void TEST_CASE3(void) {
 void TEST_CASE4(void) {
   uint64_t vxsat = -1;
   VSET(4, e32, m1);
-  VLOAD_32(v1, 1, 2, 0xFFFFFFFD, 0x7FFFFFFC);
+  VLOAD_32(v1, 1, 0x7FFFFFFC, 0xFFFFFFFD, 2);
   VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
   VCLEAR(v3);
   __asm__ volatile("vsadd.vi v3, v1, 5, v0.t" ::);
-  VCMP_U32(4, v3, 0, 7, 0, 0x7FFFFFFF);
+  VCMP_U32(4, v3, 0, 0x7FFFFFFF, 0, 7);
   read_vxsat(vxsat);
   check_vxsat(4, vxsat, 1);
   check_vxsat(4, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
@@ -101,12 +101,12 @@ void TEST_CASE7(void) {
 void TEST_CASE8(void) {
   uint64_t vxsat = -1;
   VSET(4, e8, m1);
-  VLOAD_8(v1, 1, 2, 3, 154);
-  VLOAD_8(v2, 1, 2, 3, 124);
+  VLOAD_8(v1, 1, 154, 3, 2);
+  VLOAD_8(v2, 1, 124, 3, 2);
   VLOAD_8(v0, 0xA, 0x0, 0x0, 0x0);
   VCLEAR(v3);
   __asm__ volatile("vsaddu.vv v3, v1, v2, v0.t" ::);
-  VCMP_U8(8, v3, 0, 4, 0, 255);
+  VCMP_U8(8, v3, 0, 255, 0, 4);
   read_vxsat(vxsat);
   check_vxsat(8, vxsat, 1);
   check_vxsat(8, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
@@ -127,11 +127,11 @@ void TEST_CASE9(void) {
 void TEST_CASE10(void) {
   uint64_t vxsat = -1;
   VSET(4, e32, m1);
-  VLOAD_32(v1, 1, 2, 0xFFFFFFFD, 0xFFFFFFFC);
+  VLOAD_32(v1, 1, 0xFFFFFFFC, 0xFFFFFFFD, 2);
   VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
   VCLEAR(v3);
   __asm__ volatile("vsaddu.vi v3, v1, 5, v0.t" ::);
-  VCMP_U32(10, v3, 0, 7, 0, 0xFFFFFFFF);
+  VCMP_U32(10, v3, 0, 0xFFFFFFFF, 0, 7);
   read_vxsat(vxsat);
   check_vxsat(10, vxsat, 1);
   check_vxsat(10, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros

--- a/apps/riscv-tests/isa/rv64uv/vxsat.c
+++ b/apps/riscv-tests/isa/rv64uv/vxsat.c
@@ -8,7 +8,7 @@
 #include "vector_macros.h"
 
 void TEST_CASE1(void) {
-  uint64_t vxsat;
+  uint64_t vxsat = -1;
   VSET(4, e8, m1);
   VLOAD_8(v1, -80, 2, 100, 4);
   VLOAD_8(v2, -90, 2, 50, 4);
@@ -20,7 +20,7 @@ void TEST_CASE1(void) {
 }
 
 void TEST_CASE2(void) {
-  uint64_t vxsat;
+  uint64_t vxsat = -1;
   VSET(4, e8, m1);
   VLOAD_8(v1, -80, 2, 100, 4);
   VLOAD_8(v2, -90, 2, 50, 4);
@@ -34,7 +34,7 @@ void TEST_CASE2(void) {
 }
 
 void TEST_CASE3(void) {
-  uint64_t vxsat;
+  uint64_t vxsat = -1;
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, 0x7FFFFFFB, 3, 4);
   __asm__ volatile("vsadd.vi v3, v1, 5" ::);
@@ -46,7 +46,7 @@ void TEST_CASE3(void) {
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
 void TEST_CASE4(void) {
-  uint64_t vxsat;
+  uint64_t vxsat = -1;
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, 2, 0xFFFFFFFD, 0x7FFFFFFC);
   VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
@@ -59,7 +59,7 @@ void TEST_CASE4(void) {
 }
 
 void TEST_CASE5(void) {
-  uint64_t vxsat;
+  uint64_t vxsat = -1;
   VSET(4, e32, m1);
   VLOAD_32(v1, 0x7FFFFFFD, 2, 3, 4);
   const uint32_t scalar = 5;
@@ -72,7 +72,7 @@ void TEST_CASE5(void) {
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
 void TEST_CASE6(void) {
-  uint64_t vxsat;
+  uint64_t vxsat = -1;
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, 0x7ffffffC, 3, 4);
   const uint32_t scalar = 5;
@@ -87,7 +87,7 @@ void TEST_CASE6(void) {
 
 
 void TEST_CASE7(void) {
-  uint64_t vxsat;
+  uint64_t vxsat = -1;
   VSET(4, e8, m1);
   VLOAD_8(v1, 133, 2, 220, 4);
   VLOAD_8(v2, 133, 2, 50, 4);
@@ -99,7 +99,7 @@ void TEST_CASE7(void) {
 }
 
 void TEST_CASE8(void) {
-  uint64_t vxsat;
+  uint64_t vxsat = -1;
   VSET(4, e8, m1);
   VLOAD_8(v1, 1, 2, 3, 154);
   VLOAD_8(v2, 1, 2, 3, 124);
@@ -113,7 +113,7 @@ void TEST_CASE8(void) {
 }
 
 void TEST_CASE9(void) {
-  uint64_t vxsat;
+  uint64_t vxsat = -1;
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, 0xFFFFFFFB, 3, 4);
   __asm__ volatile("vsaddu.vi v3, v1, 5" ::);
@@ -125,7 +125,7 @@ void TEST_CASE9(void) {
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
 void TEST_CASE10(void) {
-  uint64_t vxsat;
+  uint64_t vxsat = -1;
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, 2, 0xFFFFFFFD, 0xFFFFFFFC);
   VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
@@ -138,7 +138,7 @@ void TEST_CASE10(void) {
 }
 
 void TEST_CASE11(void) {
-  uint64_t vxsat;
+  uint64_t vxsat = -1;
   VSET(4, e32, m1);
   VLOAD_32(v1, 0xFFFFFFFD, 2, 3, 4);
   const uint32_t scalar = 5;
@@ -151,7 +151,7 @@ void TEST_CASE11(void) {
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
 void TEST_CASE12(void) {
-  uint64_t vxsat;
+  uint64_t vxsat = -1;
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, 0xfffffffC, 3, 4);
   const uint32_t scalar = 5;
@@ -165,7 +165,7 @@ void TEST_CASE12(void) {
 }
 
 void TEST_CASE13(void) {
-  uint64_t vxsat;
+  uint64_t vxsat = -1;
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, 0x0000FFFF, 3, 4);
   VLOAD_32(v2, 0xA, 0xFFFF0000, 0x0, 0x0);

--- a/apps/riscv-tests/isa/rv64uv/vxsat.c
+++ b/apps/riscv-tests/isa/rv64uv/vxsat.c
@@ -16,7 +16,8 @@ void TEST_CASE1(void) {
   VCMP_U8(1, v3, 0x80, 4, 127, 8);
   read_vxsat(vxsat);
   check_vxsat(1, vxsat, 1);
-  check_vxsat(1, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
+  check_vxsat(1, vxsat >> 1,
+              0); // Bits vxsat[XLEN-1:1] should be written as zeros
 }
 
 void TEST_CASE2(void) {
@@ -30,7 +31,8 @@ void TEST_CASE2(void) {
   VCMP_U8(2, v3, 0, 4, 0, 8);
   read_vxsat(vxsat);
   check_vxsat(2, vxsat, 0);
-  check_vxsat(2, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
+  check_vxsat(2, vxsat >> 1,
+              0); // Bits vxsat[XLEN-1:1] should be written as zeros
 }
 
 void TEST_CASE3(void) {
@@ -41,7 +43,8 @@ void TEST_CASE3(void) {
   VCMP_U32(3, v3, 6, 0x7FFFFFFF, 8, 9);
   read_vxsat(vxsat);
   check_vxsat(3, vxsat, 1);
-  check_vxsat(3, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
+  check_vxsat(3, vxsat >> 1,
+              0); // Bits vxsat[XLEN-1:1] should be written as zeros
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
@@ -55,7 +58,8 @@ void TEST_CASE4(void) {
   VCMP_U32(4, v3, 0, 0x7FFFFFFF, 0, 7);
   read_vxsat(vxsat);
   check_vxsat(4, vxsat, 1);
-  check_vxsat(4, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
+  check_vxsat(4, vxsat >> 1,
+              0); // Bits vxsat[XLEN-1:1] should be written as zeros
 }
 
 void TEST_CASE5(void) {
@@ -67,7 +71,8 @@ void TEST_CASE5(void) {
   VCMP_U32(5, v3, 0x7FFFFFFF, 7, 8, 9);
   read_vxsat(vxsat);
   check_vxsat(5, vxsat, 1);
-  check_vxsat(5, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
+  check_vxsat(5, vxsat >> 1,
+              0); // Bits vxsat[XLEN-1:1] should be written as zeros
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
@@ -82,9 +87,9 @@ void TEST_CASE6(void) {
   VCMP_U32(6, v3, 0, 0x7FFFFFFF, 0, 9);
   read_vxsat(vxsat);
   check_vxsat(6, vxsat, 1);
-  check_vxsat(6, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
+  check_vxsat(6, vxsat >> 1,
+              0); // Bits vxsat[XLEN-1:1] should be written as zeros
 }
-
 
 void TEST_CASE7(void) {
   uint64_t vxsat = -1;
@@ -95,7 +100,8 @@ void TEST_CASE7(void) {
   VCMP_U8(7, v3, 255, 4, 255, 8);
   read_vxsat(vxsat);
   check_vxsat(7, vxsat, 1);
-  check_vxsat(7, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
+  check_vxsat(7, vxsat >> 1,
+              0); // Bits vxsat[XLEN-1:1] should be written as zeros
 }
 
 void TEST_CASE8(void) {
@@ -109,7 +115,8 @@ void TEST_CASE8(void) {
   VCMP_U8(8, v3, 0, 255, 0, 4);
   read_vxsat(vxsat);
   check_vxsat(8, vxsat, 1);
-  check_vxsat(8, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
+  check_vxsat(8, vxsat >> 1,
+              0); // Bits vxsat[XLEN-1:1] should be written as zeros
 }
 
 void TEST_CASE9(void) {
@@ -120,7 +127,8 @@ void TEST_CASE9(void) {
   VCMP_U32(9, v3, 6, 0xFFFFFFFF, 8, 9);
   read_vxsat(vxsat);
   check_vxsat(9, vxsat, 1);
-  check_vxsat(9, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
+  check_vxsat(9, vxsat >> 1,
+              0); // Bits vxsat[XLEN-1:1] should be written as zeros
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
@@ -134,7 +142,8 @@ void TEST_CASE10(void) {
   VCMP_U32(10, v3, 0, 0xFFFFFFFF, 0, 7);
   read_vxsat(vxsat);
   check_vxsat(10, vxsat, 1);
-  check_vxsat(10, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
+  check_vxsat(10, vxsat >> 1,
+              0); // Bits vxsat[XLEN-1:1] should be written as zeros
 }
 
 void TEST_CASE11(void) {
@@ -146,7 +155,8 @@ void TEST_CASE11(void) {
   VCMP_U32(11, v3, 0xFFFFFFFF, 7, 8, 9);
   read_vxsat(vxsat);
   check_vxsat(11, vxsat, 1);
-  check_vxsat(11, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
+  check_vxsat(11, vxsat >> 1,
+              0); // Bits vxsat[XLEN-1:1] should be written as zeros
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
@@ -161,7 +171,8 @@ void TEST_CASE12(void) {
   VCMP_U32(12, v3, 0, 0xFFFFFFFF, 0, 9);
   read_vxsat(vxsat);
   check_vxsat(12, vxsat, 1);
-  check_vxsat(12, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
+  check_vxsat(12, vxsat >> 1,
+              0); // Bits vxsat[XLEN-1:1] should be written as zeros
 }
 
 void TEST_CASE13(void) {
@@ -174,22 +185,22 @@ void TEST_CASE13(void) {
   VCMP_U32(13, v3, 0xB, 0xFFFFFFFF, 3, 4);
   read_vxsat(vxsat);
   check_vxsat(13, vxsat, 0);
-  check_vxsat(13, vxsat >> 1, 0); // Bits vxsat[XLEN-1:1] should be written as zeros
+  check_vxsat(13, vxsat >> 1,
+              0); // Bits vxsat[XLEN-1:1] should be written as zeros
 }
-
 
 int main(void) {
   INIT_CHECK();
   enable_vec();
   enable_fp();
-  //vsadd.vv based cases
+  // vsadd.vv based cases
   TEST_CASE1();
   TEST_CASE2();
   TEST_CASE3();
   TEST_CASE4();
   TEST_CASE5();
   TEST_CASE6();
-  //vsaddu.vv based cases
+  // vsaddu.vv based cases
   TEST_CASE7();
   TEST_CASE8();
   TEST_CASE9();

--- a/apps/riscv-tests/isa/rv64uv/vxsat.c
+++ b/apps/riscv-tests/isa/rv64uv/vxsat.c
@@ -12,6 +12,7 @@ void TEST_CASE1(void) {
   VSET(4, e8, m1);
   VLOAD_8(v1, -80, 2, 100, 4);
   VLOAD_8(v2, -90, 2, 50, 4);
+  asm volatile("csrw vxsat, x0");
   __asm__ volatile("vsadd.vv v3, v1, v2" ::);
   VCMP_U8(1, v3, 0x80, 4, 127, 8);
   read_vxsat(vxsat);
@@ -27,6 +28,7 @@ void TEST_CASE2(void) {
   VLOAD_8(v2, -90, 2, 50, 4);
   VLOAD_8(v0, 0xA, 0x0, 0x0, 0x0);
   VCLEAR(v3);
+  asm volatile("csrw vxsat, x0");
   __asm__ volatile("vsadd.vv v3, v1, v2, v0.t" ::);
   VCMP_U8(2, v3, 0, 4, 0, 8);
   read_vxsat(vxsat);
@@ -39,6 +41,7 @@ void TEST_CASE3(void) {
   uint64_t vxsat = -1;
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, 0x7FFFFFFB, 3, 4);
+  asm volatile("csrw vxsat, x0");
   __asm__ volatile("vsadd.vi v3, v1, 5" ::);
   VCMP_U32(3, v3, 6, 0x7FFFFFFF, 8, 9);
   read_vxsat(vxsat);
@@ -54,6 +57,7 @@ void TEST_CASE4(void) {
   VLOAD_32(v1, 1, 0x7FFFFFFC, 0xFFFFFFFD, 2);
   VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
   VCLEAR(v3);
+  asm volatile("csrw vxsat, x0");
   __asm__ volatile("vsadd.vi v3, v1, 5, v0.t" ::);
   VCMP_U32(4, v3, 0, 0x7FFFFFFF, 0, 7);
   read_vxsat(vxsat);
@@ -67,6 +71,7 @@ void TEST_CASE5(void) {
   VSET(4, e32, m1);
   VLOAD_32(v1, 0x7FFFFFFD, 2, 3, 4);
   const uint32_t scalar = 5;
+  asm volatile("csrw vxsat, x0");
   __asm__ volatile("vsadd.vx v3, v1, %[A]" ::[A] "r"(scalar));
   VCMP_U32(5, v3, 0x7FFFFFFF, 7, 8, 9);
   read_vxsat(vxsat);
@@ -83,6 +88,7 @@ void TEST_CASE6(void) {
   const uint32_t scalar = 5;
   VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
   VCLEAR(v3);
+  asm volatile("csrw vxsat, x0");
   __asm__ volatile("vsadd.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
   VCMP_U32(6, v3, 0, 0x7FFFFFFF, 0, 9);
   read_vxsat(vxsat);
@@ -96,6 +102,7 @@ void TEST_CASE7(void) {
   VSET(4, e8, m1);
   VLOAD_8(v1, 133, 2, 220, 4);
   VLOAD_8(v2, 133, 2, 50, 4);
+  asm volatile("csrw vxsat, x0");
   __asm__ volatile("vsaddu.vv v3, v1, v2" ::);
   VCMP_U8(7, v3, 255, 4, 255, 8);
   read_vxsat(vxsat);
@@ -111,6 +118,7 @@ void TEST_CASE8(void) {
   VLOAD_8(v2, 1, 124, 3, 2);
   VLOAD_8(v0, 0xA, 0x0, 0x0, 0x0);
   VCLEAR(v3);
+  asm volatile("csrw vxsat, x0");
   __asm__ volatile("vsaddu.vv v3, v1, v2, v0.t" ::);
   VCMP_U8(8, v3, 0, 255, 0, 4);
   read_vxsat(vxsat);
@@ -123,6 +131,7 @@ void TEST_CASE9(void) {
   uint64_t vxsat = -1;
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, 0xFFFFFFFB, 3, 4);
+  asm volatile("csrw vxsat, x0");
   __asm__ volatile("vsaddu.vi v3, v1, 5" ::);
   VCMP_U32(9, v3, 6, 0xFFFFFFFF, 8, 9);
   read_vxsat(vxsat);
@@ -138,6 +147,7 @@ void TEST_CASE10(void) {
   VLOAD_32(v1, 1, 0xFFFFFFFC, 0xFFFFFFFD, 2);
   VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
   VCLEAR(v3);
+  asm volatile("csrw vxsat, x0");
   __asm__ volatile("vsaddu.vi v3, v1, 5, v0.t" ::);
   VCMP_U32(10, v3, 0, 0xFFFFFFFF, 0, 7);
   read_vxsat(vxsat);
@@ -151,6 +161,7 @@ void TEST_CASE11(void) {
   VSET(4, e32, m1);
   VLOAD_32(v1, 0xFFFFFFFD, 2, 3, 4);
   const uint32_t scalar = 5;
+  asm volatile("csrw vxsat, x0");
   __asm__ volatile("vsaddu.vx v3, v1, %[A]" ::[A] "r"(scalar));
   VCMP_U32(11, v3, 0xFFFFFFFF, 7, 8, 9);
   read_vxsat(vxsat);
@@ -167,6 +178,7 @@ void TEST_CASE12(void) {
   const uint32_t scalar = 5;
   VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
   VCLEAR(v3);
+  asm volatile("csrw vxsat, x0");
   __asm__ volatile("vsaddu.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
   VCMP_U32(12, v3, 0, 0xFFFFFFFF, 0, 9);
   read_vxsat(vxsat);
@@ -181,6 +193,7 @@ void TEST_CASE13(void) {
   VLOAD_32(v1, 1, 0x0000FFFF, 3, 4);
   VLOAD_32(v2, 0xA, 0xFFFF0000, 0x0, 0x0);
   VCLEAR(v3);
+  asm volatile("csrw vxsat, x0");
   __asm__ volatile("vsaddu.vv v3, v1, v2" ::);
   VCMP_U32(13, v3, 0xB, 0xFFFFFFFF, 3, 4);
   read_vxsat(vxsat);

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -90,7 +90,6 @@ package ara_pkg;
 
   typedef logic [$clog2(MAXVL+1)-1:0] vlen_t;
   typedef logic [$clog2(NrVInsn)-1:0] vid_t;
-
   typedef logic [ELEN-1:0] elen_t;
 
   //////////////////
@@ -100,6 +99,8 @@ package ara_pkg;
   typedef enum logic [6:0] {
     // Arithmetic and logic instructions
     VADD, VSUB, VADC, VSBC, VRSUB, VMINU, VMIN, VMAXU, VMAX, VAND, VOR, VXOR,
+    // Fixed point
+    VSADDU, VSADD, VSSUBU, VSSUB, VAADDU, VAADD, VASUBU, VASUB,
     // Shifts,
     VSLL, VSRL, VSRA, VNSRL, VNSRA,
     // Merge
@@ -808,6 +809,20 @@ package ara_pkg;
       end
     endcase
   endfunction : deshuffle_index
+
+  /////////////////////////
+  //  Fixed-Point        //
+  /////////////////////////
+
+  typedef logic                       vxsat_t;
+  typedef logic [1:0]                 vxrm_t;
+
+  typedef union packed {
+    logic [0:0][7:0] w64;
+    logic [1:0][3:0] w32;
+    logic [3:0][1:0] w16;
+    logic [7:0][0:0] w8;
+  } alu_vxsat_t;
 
   /////////////////////////
   //  MASKU definitions  //

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -81,34 +81,36 @@ module ara import ara_pkg::*; #(
   // Interface with the lanes
   logic      [NrLanes-1:0][4:0] fflags_ex;
   logic      [NrLanes-1:0]      fflags_ex_valid;
+  logic      [NrLanes-1:0]      vxsat_flag;
 
   ara_dispatcher #(
     .NrLanes(NrLanes)
   ) i_dispatcher (
-    .clk_i            (clk_i           ),
-    .rst_ni           (rst_ni          ),
+    .clk_i             (clk_i           ),
+    .rst_ni            (rst_ni          ),
     // Interface with Ariane
-    .acc_req_i        (acc_req_i       ),
-    .acc_req_valid_i  (acc_req_valid_i ),
-    .acc_req_ready_o  (acc_req_ready_o ),
-    .acc_resp_o       (acc_resp_o      ),
-    .acc_resp_valid_o (acc_resp_valid_o),
-    .acc_resp_ready_i (acc_resp_ready_i),
+    .acc_req_i         (acc_req_i       ),
+    .acc_req_valid_i   (acc_req_valid_i ),
+    .acc_req_ready_o   (acc_req_ready_o ),
+    .acc_resp_o        (acc_resp_o      ),
+    .acc_resp_valid_o  (acc_resp_valid_o),
+    .acc_resp_ready_i  (acc_resp_ready_i),
     // Interface with the sequencer
-    .ara_req_o        (ara_req         ),
-    .ara_req_valid_o  (ara_req_valid   ),
-    .ara_req_ready_i  (ara_req_ready   ),
-    .ara_resp_i       (ara_resp        ),
-    .ara_resp_valid_i (ara_resp_valid  ),
-    .ara_idle_i       (ara_idle        ),
+    .ara_req_o         (ara_req         ),
+    .ara_req_valid_o   (ara_req_valid   ),
+    .ara_req_ready_i   (ara_req_ready   ),
+    .ara_resp_i        (ara_resp        ),
+    .ara_resp_valid_i  (ara_resp_valid  ),
+    .ara_idle_i        (ara_idle        ),
     // Interface with the lanes
-    .fflags_ex_i      (fflags_ex       ),
-    .fflags_ex_valid_i(fflags_ex_valid ),
+    .vxsat_flag_i      (vxsat_flag      ),
+    .fflags_ex_i       (fflags_ex       ),
+    .fflags_ex_valid_i (fflags_ex_valid ),
     // Interface with the Vector Store Unit
-    .core_st_pending_o(core_st_pending ),
-    .load_complete_i  (load_complete   ),
-    .store_complete_i (store_complete  ),
-    .store_pending_i  (store_pending   )
+    .core_st_pending_o (core_st_pending ),
+    .load_complete_i   (load_complete   ),
+    .store_complete_i  (store_complete  ),
+    .store_pending_i   (store_pending   )
   );
 
   /////////////////
@@ -223,6 +225,7 @@ module ara import ara_pkg::*; #(
       .scan_data_o                     (/* Unused */                        ),
       .lane_id_i                       (lane[idx_width(NrLanes)-1:0]        ),
       // Interface with the dispatcher
+      .vxsat_flag_o                    (vxsat_flag[lane]                    ),
       .fflags_ex_o                     (fflags_ex[lane]                     ),
       .fflags_ex_valid_o               (fflags_ex_valid[lane]               ),
       // Interface with the sequencer

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -82,6 +82,7 @@ module ara import ara_pkg::*; #(
   logic      [NrLanes-1:0][4:0] fflags_ex;
   logic      [NrLanes-1:0]      fflags_ex_valid;
   logic      [NrLanes-1:0]      vxsat_flag;
+  vxrm_t     [NrLanes-1:0]      alu_vxrm;
 
   ara_dispatcher #(
     .NrLanes(NrLanes)
@@ -104,6 +105,7 @@ module ara import ara_pkg::*; #(
     .ara_idle_i        (ara_idle        ),
     // Interface with the lanes
     .vxsat_flag_i      (vxsat_flag      ),
+    .alu_vxrm_o        (alu_vxrm        ),
     .fflags_ex_i       (fflags_ex       ),
     .fflags_ex_valid_i (fflags_ex_valid ),
     // Interface with the Vector Store Unit
@@ -226,6 +228,7 @@ module ara import ara_pkg::*; #(
       .lane_id_i                       (lane[idx_width(NrLanes)-1:0]        ),
       // Interface with the dispatcher
       .vxsat_flag_o                    (vxsat_flag[lane]                    ),
+      .alu_vxrm_i                      (alu_vxrm[lane]                      ),
       .fflags_ex_o                     (fflags_ex[lane]                     ),
       .fflags_ex_valid_o               (fflags_ex_valid[lane]               ),
       // Interface with the sequencer

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -33,6 +33,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
     // Interface with the lanes
     input  logic              [NrLanes-1:0][4:0] fflags_ex_i,
     input  logic              [NrLanes-1:0]      fflags_ex_valid_i,
+    input  logic              [NrLanes-1:0]      vxsat_flag_i,
     // Interface with the Vector Store Unit
     output logic                                 core_st_pending_o,
     input  logic                                 load_complete_i,
@@ -53,11 +54,14 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
   vlen_t  vstart_d, vstart_q;
   vlen_t  vl_d, vl_q;
   vtype_t vtype_d, vtype_q;
+  vxsat_t vxsat_d, vxsat_q;
+  vxrm_t  vxrm_d, vxrm_q;
 
   `FF(vstart_q, vstart_d, '0)
   `FF(vl_q, vl_d, '0)
   `FF(vtype_q, vtype_d, '{vill: 1'b1, default: '0})
-
+  `FF(vxsat_q, vxsat_d, '0)
+  `FF(vxrm_q, vxrm_d, '0)
   // Converts between the internal representation of `vtype_t` and the full XLEN-bit CSR.
   function automatic riscv::xlen_t xlen_vtype(vtype_t vtype);
     xlen_vtype = {vtype.vill, {riscv::XLEN-9{1'b0}}, vtype.vma, vtype.vta, vtype.vsew,
@@ -196,6 +200,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
     lmul_vs2     = vtype_q.vlmul;
     lmul_vs1     = vtype_q.vlmul;
     illegal_insn = 1'b0;
+    vxsat_d      = vxsat_q;
 
     is_vload      = 1'b0;
     is_vstore     = 1'b0;
@@ -236,6 +241,8 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
     // The token must change at every new instruction
     ara_req_d.token = (ara_req_valid_o && ara_req_ready_i) ? ~ara_req_o.token : ara_req_o.token;
 
+    // Saturation in any lane will raise vxsat flag
+    vxsat_d = |vxsat_flag_i;
     // Special states
     case (state_q)
       // Is Ara idle?
@@ -471,6 +478,10 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     ara_req_d.op      = ara_pkg::VMERGE;
                     ara_req_d.use_vs2 = !insn.varith_type.vm; // vmv.v.v does not use vs2
                   end
+                  6'b100000: ara_req_d.op = ara_pkg::VSADDU;
+                  6'b100001: ara_req_d.op = ara_pkg::VSADD;
+                  6'b100010: ara_req_d.op = ara_pkg::VSSUBU;
+                  6'b100011: ara_req_d.op = ara_pkg::VSSUB;
                   6'b100101: ara_req_d.op = ara_pkg::VSLL;
                   6'b101000: ara_req_d.op = ara_pkg::VSRL;
                   6'b101001: ara_req_d.op = ara_pkg::VSRA;
@@ -681,6 +692,10 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     ara_req_d.op      = ara_pkg::VMERGE;
                     ara_req_d.use_vs2 = !insn.varith_type.vm; // vmv.v.x does not use vs2
                   end
+                  6'b100000: ara_req_d.op = ara_pkg::VSADDU;
+                  6'b100001: ara_req_d.op = ara_pkg::VSADD;
+                  6'b100010: ara_req_d.op = ara_pkg::VSSUBU;
+                  6'b100011: ara_req_d.op = ara_pkg::VSSUB;
                   6'b100101: ara_req_d.op = ara_pkg::VSLL;
                   6'b101000: ara_req_d.op = ara_pkg::VSRL;
                   6'b101001: ara_req_d.op = ara_pkg::VSRA;
@@ -833,6 +848,8 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     ara_req_d.op      = ara_pkg::VMERGE;
                     ara_req_d.use_vs2 = !insn.varith_type.vm; // vmv.v.i does not use vs2
                   end
+                  6'b100000: ara_req_d.op = ara_pkg::VSADDU;
+                  6'b100001: ara_req_d.op = ara_pkg::VSADD;
                   6'b100101: ara_req_d.op = ara_pkg::VSLL;
                   6'b100111: begin // vmv<nr>r.v
                     automatic int unsigned vlmax;
@@ -988,6 +1005,10 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     ara_req_d.conversion_vs1 = OpQueueReductionZExt;
                     ara_req_d.cvt_resize     = resize_e'(2'b10);
                   end
+                  6'b001000: ara_req_d.op = ara_pkg::VAADDU;
+                  6'b001001: ara_req_d.op = ara_pkg::VAADD;
+                  6'b001010: ara_req_d.op = ara_pkg::VASUBU;
+                  6'b001011: ara_req_d.op = ara_pkg::VASUB;
                   6'b011000: begin
                     ara_req_d.op        = ara_pkg::VMANDN;
                     ara_req_d.use_vd_op = 1'b1;
@@ -1287,6 +1308,10 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
 
                 // Decode based on the func6 field
                 unique case (insn.varith_type.func6)
+                  6'b001000: ara_req_d.op = ara_pkg::VAADDU;
+                  6'b001001: ara_req_d.op = ara_pkg::VAADD;
+                  6'b001010: ara_req_d.op = ara_pkg::VASUBU;
+                  6'b001011: ara_req_d.op = ara_pkg::VASUB;
                   // Slides
                   6'b001110: begin // vslide1up
                     ara_req_d.op      = ara_pkg::VSLIDEUP;
@@ -2443,6 +2468,14 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     vstart_d          = acc_req_i.rs1;
                     acc_resp_o.result = vstart_q;
                   end
+                  riscv::CSR_VXRM: begin
+                    vxrm_d            = acc_req_i.rs1[1:0];
+                    acc_resp_o.result = vlen_t'(vxrm_q);
+                  end
+                  riscv::CSR_VXSAT: begin
+                    vxsat_d           = acc_req_i.rs1[0];
+                    acc_resp_o.result = vlen_t'(vxsat_q);
+                  end
                   default: acc_resp_o.error = 1'b1;
                 endcase
               end
@@ -2467,6 +2500,14 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     // Only reads are allowed
                     if (acc_req_i.insn.itype.rs1 == '0) acc_resp_o.result = VLENB;
                     else acc_resp_o.error                                 = 1'b1;
+                  end
+                  riscv::CSR_VXRM: begin
+                    vxrm_d            = vxrm_q | vlen_t'(acc_req_i.rs1[1:0]);
+                    acc_resp_o.result = vlen_t'(vxrm_q);
+                  end
+                  riscv::CSR_VXSAT: begin
+                    vxsat_d           = vxsat_q | vlen_t'(acc_req_i.rs1[0]);
+                    acc_resp_o.result = vlen_t'(vxsat_q);
                   end
                   default: acc_resp_o.error = 1'b1;
                 endcase
@@ -2503,6 +2544,10 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                   riscv::CSR_VSTART: begin
                     vstart_d          = vlen_t'(acc_req_i.insn.itype.rs1);
                     acc_resp_o.result = vstart_q;
+                  end
+                  riscv::CSR_VXRM: begin
+                    vxrm_d            = vxrm_t'(acc_req_i.insn.itype.rs1[1:0]);
+                    acc_resp_o.result = vlen_t'(vxrm_q);
                   end
                   default: acc_resp_o.error = 1'b1;
                 endcase

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -246,7 +246,8 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
 
     // Saturation in any lane will raise vxsat flag
     vxsat_d = |vxsat_flag_i;
-    alu_vxrm_o = vxrm_q;
+    // Fixed-point rounding mode is applied to all lanes
+    for (int lane = 0; lane < NrLanes; lane++) alu_vxrm_o[lane] = vxrm_q;
     // Rounding mode is shared between all lanes
     for (int lane = 0; lane < NrLanes; lane++) acc_resp_o.fflags |= fflags_ex_i[lane];
     // Special states

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -34,6 +34,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     input  logic     [cf_math_pkg::idx_width(NrLanes)-1:0] lane_id_i,
     // Interface with the dispatcher
     output logic                                           vxsat_flag_o,
+    input  vxrm_t                                          alu_vxrm_i,
     output logic     [4:0]                                 fflags_ex_o,
     output logic                                           fflags_ex_valid_o,
     // Interface with the sequencer
@@ -358,6 +359,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     .lane_id_i            (lane_id_i                              ),
     // Interface with Dispatcher
     .vxsat_flag_o         (vxsat_flag_o                           ),
+    .alu_vxrm_i           (alu_vxrm_i                             ),
     // Interface with CVA6
     .fflags_ex_o          (fflags_ex_o                            ),
     .fflags_ex_valid_o    (fflags_ex_valid_o                      ),

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -33,6 +33,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     // Lane ID
     input  logic     [cf_math_pkg::idx_width(NrLanes)-1:0] lane_id_i,
     // Interface with the dispatcher
+    output logic                                           vxsat_flag_o,
     output logic     [4:0]                                 fflags_ex_o,
     output logic                                           fflags_ex_valid_o,
     // Interface with the sequencer
@@ -355,6 +356,8 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     .clk_i                (clk_i                                  ),
     .rst_ni               (rst_ni                                 ),
     .lane_id_i            (lane_id_i                              ),
+    // Interface with Dispatcher
+    .vxsat_flag_o         (vxsat_flag_o                           ),
     // Interface with CVA6
     .fflags_ex_o          (fflags_ex_o                            ),
     .fflags_ex_valid_o    (fflags_ex_valid_o                      ),

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -181,7 +181,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
                   2'b00: r = sum[0];
                   2'b01: r = &sum[1:0];
                   2'b10: r = 1'b0;
-                  2'b11: r = !sum[1] & sum[0];
+                  2'b11: r = !sum[1] & (sum[0]!=0);
                 endcase
                 res.w8[b] = (op_i == VAADDU) ? sum[8:1] + r : {sum[7], sum[7:1]} + r;
               end
@@ -191,7 +191,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
                   2'b00: r = sum[0];
                   2'b01: r = &sum[1:0];
                   2'b10: r = 1'b0;
-                  2'b11: r = !sum[1] & sum[0];
+                  2'b11: r = !sum[1] & (sum[0]!=0);
                 endcase
                 res.w16[b] = (op_i == VAADDU) ? sum[16:1] + r : {sum[15], sum[15:1]} + r;
               end
@@ -201,7 +201,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
                   2'b00: r = sum[0];
                   2'b01: r = &sum[1:0];
                   2'b10: r = 1'b0;
-                  2'b11: r = !sum[1] & sum[0];
+                  2'b11: r = !sum[1] & (sum[0]!=0);
                 endcase
                 res.w32[b] = (op_i == VAADDU) ? sum[32:1] + r : {sum[31], sum[31:1]} + r;
               end
@@ -211,7 +211,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
                   2'b00: r = sum[0];
                   2'b01: r = &sum[1:0];
                   2'b10: r = 1'b0;
-                  2'b11: r = !sum[1] & sum[0];
+                  2'b11: r = !sum[1] & (sum[0]!=0);
                 endcase
                 res.w64[b] = (op_i == VAADDU) ? sum[64:1] + r : {sum[63], sum[63:1]} + r;
               end
@@ -317,7 +317,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
                   2'b00: r = sub[0];
                   2'b01: r = &sub[1:0];
                   2'b10: r = 1'b0;
-                  2'b11: r = !sub[1] & sub[0];
+                  2'b11: r = !sub[1] & (sub[0]!=0);
                 endcase
                 res.w8[b] = (op_i == VSSUBU) ? (sub[7:0] >> 1) + r : $signed(sub[7:0]) >>> 1 + r;
               end
@@ -327,7 +327,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
                   2'b00: r = sub[0];
                   2'b01: r = &sub[1:0];
                   2'b10: r = 1'b0;
-                  2'b11: r = !sub[1] & sub[0];
+                  2'b11: r = !sub[1] & (sub[0]!=0);
                 endcase
                 res.w16[b] = (op_i == VSSUBU) ? (sub[15:0] >> 1) + r : $signed(sub[15:0]) >>> 1 + r;
               end
@@ -337,7 +337,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
                   2'b00: r = sub[0];
                   2'b01: r = &sub[1:0];
                   2'b10: r = 1'b0;
-                  2'b11: r = !sub[1] & sub[0];
+                  2'b11: r = !sub[1] & (sub[0]!=0);
                 endcase
                 res.w32[b] = (op_i == VSSUBU) ? (sub[31:0] >> 1) + r : $signed(sub[31:0]) >>> 1 + r;
               end
@@ -347,7 +347,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
                   2'b00: r = sub[0];
                   2'b01: r = &sub[1:0];
                   2'b10: r = 1'b0;
-                  2'b11: r = !sub[1] & sub[0];
+                  2'b11: r = !sub[1] & (sub[0]!=0);
                 endcase
                 res.w64[b] = (op_i == VSSUBU) ? (sub[63:0] >> 1) + r : $signed(sub[63:0]) >>> 1 + r;
               end

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -21,16 +21,10 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
     input  ara_op_e    op_i,
     input  vew_e       vew_i,
     output alu_vxsat_t vxsat_o,
+    input  vxrm_t      vxrm_i,
     output elen_t      result_o
   );
   
-  // Temp logic rounding mode CSR (vxrm_i) needs to be integrated as input to alu
-  vxrm_t       vxrm_i;
-  logic        r;
-  // logic        vxsat;
-
-  assign vxrm_i = 0;
-
   ///////////////////
   //  Definitions  //
   ///////////////////
@@ -57,9 +51,11 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
 
   alu_sat_operand_t sat_sum, sat_sub;
   alu_vxsat_t vxsat;
-  
+  vxrm_t      vxrm;
+  logic       r;
+
+  assign vxrm = vxrm_i;
   assign vxsat_o = vxsat;
-  // assign vxsat_o = |vxsat.w8;
 
   ///////////////////
   //  Comparisons  //
@@ -181,7 +177,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
         VAADD, VAADDU: unique case (vew_i)
             EW8: for (int b = 0; b < 8; b++) begin
               automatic logic [ 8:0] sum = opa.w8 [b] + opb.w8 [b];
-                unique case (vxrm_i)
+                unique case (vxrm)
                   2'b00: r = sum[0];
                   2'b01: r = &sum[1:0];
                   2'b10: r = 1'b0;
@@ -191,7 +187,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
               end
             EW16: for (int b = 0; b < 4; b++) begin
                 automatic logic [16:0] sum = opa.w16[b] + opb.w16[b];
-                unique case (vxrm_i)
+                unique case (vxrm)
                   2'b00: r = sum[0];
                   2'b01: r = &sum[1:0];
                   2'b10: r = 1'b0;
@@ -201,7 +197,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
               end
             EW32: for (int b = 0; b < 2; b++) begin
                 automatic logic [32:0] sum = opa.w32[b] + opb.w32[b];
-                unique case (vxrm_i)
+                unique case (vxrm)
                   2'b00: r = sum[0];
                   2'b01: r = &sum[1:0];
                   2'b10: r = 1'b0;
@@ -211,7 +207,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
               end
             EW64: for (int b = 0; b < 1; b++) begin
                 automatic logic [64:0] sum = opa.w64[b] + opb.w64[b];
-                unique case (vxrm_i)
+                unique case (vxrm)
                   2'b00: r = sum[0];
                   2'b01: r = &sum[1:0];
                   2'b10: r = 1'b0;
@@ -317,7 +313,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
         VASUB, VASUBU: unique case (vew_i)
             EW8: for (int b = 0; b < 8; b++) begin
                 automatic logic [ 8:0] sub = opb.w8 [b] - opa.w8 [b];
-                unique case (vxrm_i)
+                unique case (vxrm)
                   2'b00: r = sub[0];
                   2'b01: r = &sub[1:0];
                   2'b10: r = 1'b0;
@@ -327,7 +323,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
               end
             EW16: for (int b = 0; b < 4; b++) begin
                 automatic logic [ 16:0] sub = opb.w16[b] - opa.w16[b];
-                unique case (vxrm_i)
+                unique case (vxrm)
                   2'b00: r = sub[0];
                   2'b01: r = &sub[1:0];
                   2'b10: r = 1'b0;
@@ -337,7 +333,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
               end
             EW32: for (int b = 0; b < 2; b++) begin
                 automatic logic [ 32:0] sub = opb.w32[b] - opa.w32[b];
-                unique case (vxrm_i)
+                unique case (vxrm)
                   2'b00: r = sub[0];
                   2'b01: r = &sub[1:0];
                   2'b10: r = 1'b0;
@@ -347,7 +343,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
               end
             EW64: for (int b = 0; b < 1; b++) begin
                 automatic logic [ 64:0] sub = opb.w64[b] - opa.w64[b];
-                unique case (vxrm_i)
+                unique case (vxrm)
                   2'b00: r = sub[0];
                   2'b01: r = &sub[1:0];
                   2'b10: r = 1'b0;

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -319,7 +319,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
                   2'b10: r = 1'b0;
                   2'b11: r = !sub[1] & (sub[0]!=0);
                 endcase
-                res.w8[b] = (op_i == VSSUBU) ? (sub[7:0] >> 1) + r : $signed(sub[7:0]) >>> 1 + r;
+                res.w8[b] = (op_i == VSSUBU) ? (sub[7:0] >> 1) + r : {sub[7], sub[7:1]} + r;
               end
             EW16: for (int b = 0; b < 4; b++) begin
                 automatic logic [ 16:0] sub = opb.w16[b] - opa.w16[b];
@@ -329,7 +329,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
                   2'b10: r = 1'b0;
                   2'b11: r = !sub[1] & (sub[0]!=0);
                 endcase
-                res.w16[b] = (op_i == VSSUBU) ? (sub[15:0] >> 1) + r : $signed(sub[15:0]) >>> 1 + r;
+                res.w16[b] = (op_i == VSSUBU) ? (sub[15:0] >> 1) + r : {sub[15], sub[15:1]} + r;
               end
             EW32: for (int b = 0; b < 2; b++) begin
                 automatic logic [ 32:0] sub = opb.w32[b] - opa.w32[b];
@@ -339,7 +339,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
                   2'b10: r = 1'b0;
                   2'b11: r = !sub[1] & (sub[0]!=0);
                 endcase
-                res.w32[b] = (op_i == VSSUBU) ? (sub[31:0] >> 1) + r : $signed(sub[31:0]) >>> 1 + r;
+                res.w32[b] = (op_i == VSSUBU) ? (sub[31:0] >> 1) + r : {sub[31], sub[31:1]} + r;
               end
             EW64: for (int b = 0; b < 1; b++) begin
                 automatic logic [ 64:0] sub = opb.w64[b] - opa.w64[b];
@@ -349,7 +349,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
                   2'b10: r = 1'b0;
                   2'b11: r = !sub[1] & (sub[0]!=0);
                 endcase
-                res.w64[b] = (op_i == VSSUBU) ? (sub[63:0] >> 1) + r : $signed(sub[63:0]) >>> 1 + r;
+                res.w64[b] = (op_i == VSSUBU) ? (sub[63:0] >> 1) + r : {sub[63], sub[63:1]} + r;
               end
           endcase
 

--- a/hardware/src/lane/valu.sv
+++ b/hardware/src/lane/valu.sv
@@ -21,6 +21,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
     input  logic[idx_width(NrLanes)-1:0] lane_id_i,
     // Interface with Dispatcher
     output logic                         vxsat_flag_o,
+    input  vxrm_t                        alu_vxrm_i,
     // Interface with the lane sequencer
     input  vfu_operation_t               vfu_operation_i,
     input  logic                         vfu_operation_valid_i,
@@ -357,6 +358,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
     .op_i              (vinsn_issue_q.op                                                ),
     .vew_i             (vinsn_issue_q.vtype.vsew                                        ),
     .vxsat_o           (alu_vxsat                                                       ),
+    .vxrm_i            (alu_vxrm_i                                                      ),
     .result_o          (valu_result                                                     )
   );
 

--- a/hardware/src/lane/valu.sv
+++ b/hardware/src/lane/valu.sv
@@ -19,6 +19,8 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
     input  logic                         clk_i,
     input  logic                         rst_ni,
     input  logic[idx_width(NrLanes)-1:0] lane_id_i,
+    // Interface with Dispatcher
+    output logic                         vxsat_flag_o,
     // Interface with the lane sequencer
     input  vfu_operation_t               vfu_operation_i,
     input  logic                         vfu_operation_valid_i,
@@ -343,6 +345,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
 
   elen_t valu_result;
   logic  valu_valid;
+  alu_vxsat_t alu_vxsat;
 
   simd_alu i_simd_alu (
     .operand_a_i       (alu_operand_a                                                   ),
@@ -353,8 +356,11 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
     .narrowing_select_i(narrowing_select_q                                              ),
     .op_i              (vinsn_issue_q.op                                                ),
     .vew_i             (vinsn_issue_q.vtype.vsew                                        ),
+    .vxsat_o           (alu_vxsat                                                       ),
     .result_o          (valu_result                                                     )
   );
+
+  // Vector saturation flag validation signal
 
   ///////////////
   //  Control  //
@@ -405,7 +411,6 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
     ////////////////////////////////////////
     //  Write data into the result queue  //
     ////////////////////////////////////////
-
     if (vinsn_issue_valid || alu_state_q != NO_REDUCTION) begin
       case (alu_state_q)
         NO_REDUCTION: begin
@@ -438,6 +443,9 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
               result_queue_d[result_queue_write_pnt_q].mask  = vinsn_issue_q.vfu == VFU_MaskUnit;
               if (!narrowing(vinsn_issue_q.op) || !narrowing_select_q)
                 result_queue_d[result_queue_write_pnt_q].be = be(element_cnt, vinsn_issue_q.vtype.vsew) & (vinsn_issue_q.vm || vinsn_issue_q.op inside {VMERGE, VADC, VSBC} ? {StrbWidth{1'b1}} : mask_i);
+              
+                // Did Alu saturated when computing any elemnts?
+              vxsat_flag_o = alu_vxsat & result_queue_d[result_queue_write_pnt_q].be;
 
               // Is this a narrowing instruction?
               if (narrowing(vinsn_issue_q.op)) begin

--- a/hardware/src/lane/valu.sv
+++ b/hardware/src/lane/valu.sv
@@ -445,7 +445,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
               result_queue_d[result_queue_write_pnt_q].mask  = vinsn_issue_q.vfu == VFU_MaskUnit;
               if (!narrowing(vinsn_issue_q.op) || !narrowing_select_q)
                 result_queue_d[result_queue_write_pnt_q].be = be(element_cnt, vinsn_issue_q.vtype.vsew) & (vinsn_issue_q.vm || vinsn_issue_q.op inside {VMERGE, VADC, VSBC} ? {StrbWidth{1'b1}} : mask_i);
-              
+
                 // Did Alu saturated when computing any elemnts?
               vxsat_flag_o = alu_vxsat & result_queue_d[result_queue_write_pnt_q].be;
 

--- a/hardware/src/lane/vector_fus_stage.sv
+++ b/hardware/src/lane/vector_fus_stage.sv
@@ -22,6 +22,7 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg
     input  logic [idx_width(NrLanes)-1:0]     lane_id_i,
     // Interface with Dispatcher
     output logic                              vxsat_flag_o,
+    input  vxrm_t                             alu_vxrm_i,
     // Interface with CVA6
     output logic           [4:0]              fflags_ex_o,
     output logic                              fflags_ex_valid_o,
@@ -93,6 +94,7 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg
     .lane_id_i            (lane_id_i                      ),
     // Interface with Dispatcher
     .vxsat_flag_o         (vxsat_flag_o                   ),
+    .alu_vxrm_i           (alu_vxrm_i                     ),
     // Interface with the lane sequencer
     .vfu_operation_i      (vfu_operation_i                ),
     .vfu_operation_valid_i(vfu_operation_valid_i          ),

--- a/hardware/src/lane/vector_fus_stage.sv
+++ b/hardware/src/lane/vector_fus_stage.sv
@@ -20,6 +20,8 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg
     input  logic                              clk_i,
     input  logic                              rst_ni,
     input  logic [idx_width(NrLanes)-1:0]     lane_id_i,
+    // Interface with Dispatcher
+    output logic                              vxsat_flag_o,
     // Interface with CVA6
     output logic           [4:0]              fflags_ex_o,
     output logic                              fflags_ex_valid_o,
@@ -89,6 +91,8 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg
     .clk_i                (clk_i                          ),
     .rst_ni               (rst_ni                         ),
     .lane_id_i            (lane_id_i                      ),
+    // Interface with Dispatcher
+    .vxsat_flag_o         (vxsat_flag_o                   ),
     // Interface with the lane sequencer
     .vfu_operation_i      (vfu_operation_i                ),
     .vfu_operation_valid_i(vfu_operation_valid_i          ),

--- a/hardware/tb/ara_tb.sv
+++ b/hardware/tb/ara_tb.sv
@@ -102,7 +102,7 @@ module ara_tb;
     if (binary != "") begin
       // Read ELF
       read_elf(binary);
-      $display("Loading %s", binary);
+      $display("Loading ELF file %s", binary);
       while (get_section(address, length)) begin
         // Read sections
         automatic int nwords = (length + AxiWideBeWidth - 1)/AxiWideBeWidth;
@@ -123,6 +123,9 @@ module ara_tb;
             $display("Cannot initialize address %x, which doesn't fall into the L2 region.", address);
         end
       end
+    end else begin
+        $error("Expecting a firmware to run, non was provided!");
+        $finish;
     end
   end : dram_init
 


### PR DESCRIPTION
This PR adds two tests `vxrm.c` and `vxsat.c` which checks for the rounding modes implementation and setting of saturation bit respectively. Checks to test upper bits of both registers are also added (The upper bits, `vxrm[XLEN-1:2]`, and `vxsat[XLEN-1:1]` should be written as zeros) in testcases to comply with vector specification `V1.0`.

## Changelog

### Fixed

- none

### Added

- Added test `vxrm.c` to test rounding modes, and for upper bits (`vxrm[XLEN-1:2]` should be `0`)
- Added test `vxsat.c` to test saturation bit, and for upper bits (`vxsat[XLEN-1:1]` should be `0`)

### Changed

- Changes in RTL implementation relevant to `vxsat` register (in `vasub` & `vasubu` fixed point instructions)

## Checklist

- [ ] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
