### PR TITLE
misa.c and mstatus_vs_sd.c test addition

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -23,7 +23,7 @@
 	url = https://github.com/pulp-platform/common_verification.git
 [submodule "hardware/deps/cva6"]
 	path = hardware/deps/cva6
-	url = https://github.com/pulp-platform/cva6.git
+	url = https://github.com/10x-Engineers/cva6.git
 [submodule "toolchain/newlib"]
 	path = toolchain/newlib
 	url = https://sourceware.org/git/newlib-cygwin.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -26,7 +26,7 @@ packages:
     revision: 3245e44ec49c1cdcd19eb298cd81f0672eaf81ca
     version: ~
     source:
-      Git: "https://github.com/pulp-platform/cva6.git"
+      Git: "https://github.com/10x-Engineers/cva6.git"
     dependencies: []
   tech_cells_generic:
     revision: 203038f857158ae4634c47ce0281f402cc2a1344

--- a/Bender.yml
+++ b/Bender.yml
@@ -10,7 +10,7 @@ package:
 dependencies:
   axi:                { git: "https://github.com/pulp-platform/axi.git",                version: 0.29.1 }
   common_cells:       { git: "https://github.com/pulp-platform/common_cells.git",       version: 1.22.1 }
-  cva6:               { git: "https://github.com/pulp-platform/cva6.git",               rev: acc_port   }
+  cva6:               { git: "https://github.com/10x-Engineers/cva6.git",               rev: acc_port   }
   tech_cells_generic: { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.1  }
 
 workspace:

--- a/apps/riscv-tests/isa/rv64uv/misa.c
+++ b/apps/riscv-tests/isa/rv64uv/misa.c
@@ -30,14 +30,14 @@ void mtvec_handler(void)
 
   // Read mcause
   asm volatile("csrr t0, mcause");
-  
+
   // Read mepc
   asm volatile("csrr t1, mepc");
-  
+
   // Increment return address by 4
   asm volatile("addi t1, t1, 4");
   asm volatile("csrw mepc, t1");
-  
+
   // Filter with mcause and handle here
 
 asm volatile("mret");

--- a/apps/riscv-tests/isa/rv64uv/misa.c
+++ b/apps/riscv-tests/isa/rv64uv/misa.c
@@ -1,0 +1,55 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
+//         Basile Bougenot <bbougenot@student.ethz.ch>
+
+#include "vector_macros.h"
+
+char str_1[] = "V";
+
+void TEST_CASE1(void) {
+  uint64_t misa = -1;
+  uint64_t misa_var = 0;
+  VSET(16, e8, m1);
+  VLOAD_8(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_8(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vadd.vv v3, v1, v2");
+  VCMP_U8(1, v3, 2, 4, 6, 8, 10, 12, 14, 16, 2, 4, 6, 8, 10, 12, 14, 16);
+  asm volatile("ecall");
+  read_misa(misa);
+  misa_var = misa >> 21;
+  check_misa(str_1, misa_var & 1, 1);
+}
+
+// Exception Handler
+
+void mtvec_handler(void)
+{
+
+  // Read mcause
+  asm volatile("csrr t0, mcause");
+  
+  // Read mepc
+  asm volatile("csrr t1, mepc");
+  
+  // Increment return address by 4
+  asm volatile("addi t1, t1, 4");
+  asm volatile("csrw mepc, t1");
+  
+  // Filter with mcause and handle here
+
+asm volatile("mret");
+}
+
+// Main
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+
+  TEST_CASE1();
+
+  EXIT_CHECK();
+}

--- a/apps/riscv-tests/isa/rv64uv/misa.c
+++ b/apps/riscv-tests/isa/rv64uv/misa.c
@@ -25,8 +25,7 @@ void TEST_CASE1(void) {
 
 // Exception Handler
 
-void mtvec_handler(void)
-{
+void mtvec_handler(void) {
 
   // Read mcause
   asm volatile("csrr t0, mcause");
@@ -40,7 +39,7 @@ void mtvec_handler(void)
 
   // Filter with mcause and handle here
 
-asm volatile("mret");
+  asm volatile("mret");
 }
 
 // Main

--- a/apps/riscv-tests/isa/rv64uv/mstatus_vs_sd.c
+++ b/apps/riscv-tests/isa/rv64uv/mstatus_vs_sd.c
@@ -30,14 +30,14 @@ void mtvec_handler(void)
 
   // Read mcause
   asm volatile("csrr t0, mcause");
-  
+
   // Read mepc
   asm volatile("csrr t1, mepc");
-  
+
   // Increment return address by 4
   asm volatile("addi t1, t1, 4");
   asm volatile("csrw mepc, t1");
-  
+
   // Filter with mcause and handle here
 
 asm volatile("mret");

--- a/apps/riscv-tests/isa/rv64uv/mstatus_vs_sd.c
+++ b/apps/riscv-tests/isa/rv64uv/mstatus_vs_sd.c
@@ -25,8 +25,7 @@ void TEST_CASE1(void) {
 
 // Exception Handler
 
-void mtvec_handler(void)
-{
+void mtvec_handler(void) {
 
   // Read mcause
   asm volatile("csrr t0, mcause");
@@ -40,7 +39,7 @@ void mtvec_handler(void)
 
   // Filter with mcause and handle here
 
-asm volatile("mret");
+  asm volatile("mret");
 }
 
 // Main

--- a/apps/riscv-tests/isa/rv64uv/mstatus_vs_sd.c
+++ b/apps/riscv-tests/isa/rv64uv/mstatus_vs_sd.c
@@ -1,0 +1,55 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
+//         Basile Bougenot <bbougenot@student.ethz.ch>
+
+#include "vector_macros.h"
+
+char str_1[] = "VS";
+char str_2[] = "SD";
+
+void TEST_CASE1(void) {
+  uint64_t mstatus = -1;
+  VSET(16, e8, m1);
+  VLOAD_8(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_8(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vadd.vv v3, v1, v2");
+  VCMP_U8(1, v3, 2, 4, 6, 8, 10, 12, 14, 16, 2, 4, 6, 8, 10, 12, 14, 16);
+  asm volatile("ecall");
+  read_mstatus(mstatus);
+  check_mstatus(str_1, (mstatus >> 9) && 3, 3);
+  check_mstatus(str_2, (mstatus >> 63) && 1, 1);
+}
+
+// Exception Handler
+
+void mtvec_handler(void)
+{
+
+  // Read mcause
+  asm volatile("csrr t0, mcause");
+  
+  // Read mepc
+  asm volatile("csrr t1, mepc");
+  
+  // Increment return address by 4
+  asm volatile("addi t1, t1, 4");
+  asm volatile("csrw mepc, t1");
+  
+  // Filter with mcause and handle here
+
+asm volatile("mret");
+}
+
+// Main
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+
+  TEST_CASE1();
+
+  EXIT_CHECK();
+}


### PR DESCRIPTION
Added `misa.c` and `mstatus_vs_sd.c` tests to `apps/riscv-tests/isa/rv64uv` directory, Updated URL + hash to clone `hardware/deps/cva6` submodule and added support for interaction of `mstatus.VS` and `mstatus.SD` fields
## Changelog

### Fixed

- None

### Added

- Added support for the interaction of `mstatus.VS` and `mstatus.SD` fields (the interaction of `mstatus.VS` field with `mstatus.FS` and `mstatus.XS` fields was already implemented)
- Added `misa.c` and `mstatus_vs_sd.c` tests

### Changed

- Updated the URL + hash to clone `hardware/deps/cva6` submodule and updated the hash as well

## Checklist

- [ ] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
