### PR TITLE
Fixed vmerge.c and vmv.c tests

### DIFF
--- a/apps/riscv-tests/isa/rv64uv/vmerge.c
+++ b/apps/riscv-tests/isa/rv64uv/vmerge.c
@@ -38,7 +38,7 @@ void TEST_CASE1() {
 }
 
 void TEST_CASE2() {
-  const uint32_t scalar = 0xdeadbeef;
+  const uint64_t scalar = 0xdeadbeef;
 
   VSET(16, e8, m1);
   VLOAD_8(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);

--- a/apps/riscv-tests/isa/rv64uv/vmv.c
+++ b/apps/riscv-tests/isa/rv64uv/vmv.c
@@ -33,7 +33,7 @@ void TEST_CASE1() {
 }
 
 void TEST_CASE2() {
-  const uint32_t scalar = 0xdeadbeef;
+  const uint64_t scalar = 0xdeadbeef;
 
   VSET(16, e8, m1);
   VLOAD_8(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);


### PR DESCRIPTION
Fixed the expected values in `vmerge.c` and `vmv.c` tests
## Changelog

### Fixed

- Fixed the expected values of `vmerge.c` and `vmv.c` tests for sign extension test-cases

### Added

- None

### Changed

- None

## Checklist

- [ ] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
