### PR TITLE
Add support for for vmsbf, vmsof, vmsif, vid and viota mask instructions

### DIFF
--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -140,7 +140,12 @@ rv64uv_sc_tests = vaadd \
                   misa_v \
                   mstatus_vs \
                   vxsat \
-                  vxrm
+                  vxrm \
+                  vmsbf \
+                  vmsof \
+                  vmsif \
+                  viota \
+                  vid
 
 #rv64uv_sc_tests = vaadd vaaddu vadc vasub vasubu vcompress vfclass vfdiv vfirst vfrdiv vfsqrt vid viota vl vlff vl_nocheck vlx vmsbf vmsif vmsof vpopc_m vrgather vsadd vsaddu vsetvl vsetivli vsetvli vsmul vssra vssrl vssub vssubu vsux vsx
 

--- a/apps/riscv-tests/isa/rv64uv/vid.c
+++ b/apps/riscv-tests/isa/rv64uv/vid.c
@@ -10,15 +10,16 @@
 void TEST_CASE1() {
   VSET(8, e8, m1);
   __asm__ volatile("vid.v v1");
-  VEC_CMP_U8(1, v1, 0, 1, 2, 3, 4, 5, 6, 7);
+  VCMP_U8(1, v1, 0, 1, 2, 3, 4, 5, 6, 7);
 }
 
 void TEST_CASE2() {
   VSET(8, e8, m1);
-  VLOAD_U8(v0, 85, 0, 0, 0, 0, 0, 0, 0);
-  CLEAR(v1);
+  VLOAD_8(v0, 85, 0, 0, 0, 0, 0, 0, 0);
+  VCLEAR(v1);
   __asm__ volatile("vid.v v1, v0.t");
-  VEC_CMP_U8(2, v1, 0, 0, 2, 0, 4, 0, 6, 0);
+  VCMP_U8(2, v0, 85, 0, 0, 0, 0, 0, 0, 0);
+  VCMP_U8(2, v1, 0, 0, 2, 0, 4, 0, 6, 0);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vid.c
+++ b/apps/riscv-tests/isa/rv64uv/vid.c
@@ -19,7 +19,7 @@ void TEST_CASE2() {
   VCLEAR(v1);
   __asm__ volatile("vid.v v1, v0.t");
   VCMP_U8(2, v0, 85, 0, 0, 0, 0, 0, 0, 0);
-  VCMP_U8(2, v1, 0, 0, 2, 0, 4, 0, 6, 0);
+  VCMP_U8(3, v1, 0, 0, 2, 0, 4, 0, 6, 0);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/viota.c
+++ b/apps/riscv-tests/isa/rv64uv/viota.c
@@ -21,7 +21,7 @@ void TEST_CASE2() {
   VCLEAR(v2);
   __asm__ volatile("viota.m v2, v1, v0.t");
   VCMP_U8(2, v0, 199, 0, 0, 0, 0, 0, 0, 0);
-  VCMP_U8(2, v2, 0, 1, 0, 0, 0, 1, 1, 1);
+  VCMP_U8(3, v2, 0, 1, 0, 0, 0, 1, 1, 1);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/viota.c
+++ b/apps/riscv-tests/isa/rv64uv/viota.c
@@ -9,17 +9,19 @@
 
 void TEST_CASE1() {
   VSET(8, e8, m1);
-  VLOAD_U8(v1, 1, 0, 0, 1, 0, 0, 0, 1);
+  VLOAD_8(v1, 1, 0, 0, 1, 0, 0, 0, 1);
   __asm__ volatile("viota.m v2, v1");
-  VEC_CMP_U8(1, v2, 0, 1, 1, 1, 1, 1, 1, 1);
+  VCMP_U8(1, v2, 0, 1, 1, 1, 2, 2, 2, 2);
 }
 
 void TEST_CASE2() {
   VSET(8, e8, m1);
-  VLOAD_U8(v1, 1, 0, 0, 1, 0, 0, 0, 1);
-  VLOAD_U8(v0, 199, 0, 0, 0, 0, 0, 0, 0);
+  VLOAD_8(v1, 1, 0, 0, 1, 0, 0, 0, 1);
+  VLOAD_8(v0, 199, 0, 0, 0, 0, 0, 0, 0);
+  VCLEAR(v2);
   __asm__ volatile("viota.m v2, v1, v0.t");
-  VEC_CMP_U8(2, v2, 0, 1, 1, 1, 1, 1, 1, 1);
+  VCMP_U8(2, v0, 199, 0, 0, 0, 0, 0, 0, 0);
+  VCMP_U8(2, v2, 0, 1, 0, 0, 0, 1, 1, 1);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vmsbf.c
+++ b/apps/riscv-tests/isa/rv64uv/vmsbf.c
@@ -9,18 +9,18 @@
 
 void TEST_CASE1() {
   VSET(8, e8, m1);
-  VLOAD_U8(v3, 8, 0, 0, 0, 0, 0, 0, 0);
+  VLOAD_8(v3, 8, 0, 0, 0, 0, 0, 0, 0);
+  VCLEAR(v2);
   __asm__ volatile("vmsbf.m v2, v3");
-  VEC_CMP_U8(1, v2, 7, 0, 0, 0, 0, 0, 0, 0);
+  VCMP_U8(1, v2, 7, 0, 0, 0, 0, 0, 0, 0);
 }
 
 void TEST_CASE2() {
   VSET(8, e8, m1);
-  VLOAD_U8(v3, 8, 0, 0, 0, 0, 0, 0, 0);
-  VLOAD_U8(v0, 3, 0, 0, 0, 0, 0, 0, 0);
-  CLEAR(v2);
+  VLOAD_8(v3, 8, 0, 0, 0, 0, 0, 0, 0);
+  VLOAD_8(v0, 3, 0, 0, 0, 0, 0, 0, 0);
   __asm__ volatile("vmsbf.m v2, v3, v0.t");
-  VEC_CMP_U8(2, v2, 3, 0, 0, 0, 0, 0, 0, 0);
+  VCMP_U8(2, v2, 3, 0, 0, 0, 0, 0, 0, 0);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vmsbf.c
+++ b/apps/riscv-tests/isa/rv64uv/vmsbf.c
@@ -19,8 +19,10 @@ void TEST_CASE2() {
   VSET(8, e8, m1);
   VLOAD_8(v3, 8, 0, 0, 0, 0, 0, 0, 0);
   VLOAD_8(v0, 3, 0, 0, 0, 0, 0, 0, 0);
+  VCLEAR(v2);
   __asm__ volatile("vmsbf.m v2, v3, v0.t");
-  VCMP_U8(2, v2, 3, 0, 0, 0, 0, 0, 0, 0);
+  VCMP_U8(2, v0, 3, 0, 0, 0, 0, 0, 0, 0);
+  VCMP_U8(3, v2, 3, 0, 0, 0, 0, 0, 0, 0);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vmsif.c
+++ b/apps/riscv-tests/isa/rv64uv/vmsif.c
@@ -18,8 +18,10 @@ void TEST_CASE2() {
   VSET(8, e8, m1);
   VLOAD_8(v3, 8, 0, 0, 0, 0, 0, 0, 0);
   VLOAD_8(v0, 11, 0, 0, 0, 0, 0, 0, 0);
+  VCLEAR(v2);
   __asm__ volatile("vmsif.m v2, v3, v0.t");
-  VCMP_U8(2, v2, 11, 0, 0, 0, 0, 0, 0, 0);
+  VCMP_U8(2, v0, 11, 0, 0, 0, 0, 0, 0, 0);
+  VCMP_U8(3, v2, 11, 0, 0, 0, 0, 0, 0, 0);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vmsif.c
+++ b/apps/riscv-tests/isa/rv64uv/vmsif.c
@@ -9,18 +9,17 @@
 
 void TEST_CASE1() {
   VSET(8, e8, m1);
-  VLOAD_U8(v3, 8, 0, 0, 0, 0, 0, 0, 0);
+  VLOAD_8(v3, 8, 0, 0, 0, 0, 0, 0, 0);
   __asm__ volatile("vmsif.m v2, v3");
-  VEC_CMP_U8(1, v2, 15, 0, 0, 0, 0, 0, 0, 0);
+  VCMP_U8(1, v2, 15, 0, 0, 0, 0, 0, 0, 0);
 }
 
 void TEST_CASE2() {
   VSET(8, e8, m1);
-  VLOAD_U8(v3, 8, 0, 0, 0, 0, 0, 0, 0);
-  VLOAD_U8(v0, 11, 0, 0, 0, 0, 0, 0, 0);
-  CLEAR(v2);
+  VLOAD_8(v3, 8, 0, 0, 0, 0, 0, 0, 0);
+  VLOAD_8(v0, 11, 0, 0, 0, 0, 0, 0, 0);
   __asm__ volatile("vmsif.m v2, v3, v0.t");
-  VEC_CMP_U8(2, v2, 11, 0, 0, 0, 0, 0, 0, 0);
+  VCMP_U8(2, v2, 11, 0, 0, 0, 0, 0, 0, 0);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vmsof.c
+++ b/apps/riscv-tests/isa/rv64uv/vmsof.c
@@ -18,8 +18,10 @@ void TEST_CASE2() {
   VSET(8, e8, m1);
   VLOAD_8(v3, 0, 0, 0, 1, 0, 0, 0, 0);
   VLOAD_8(v0, 3, 0, 0, 0, 0, 0, 0, 0);
+  VCLEAR(v2);
   __asm__ volatile("vmsof.m v2, v3, v0.t");
-  VCMP_U8(2, v2, 0, 0, 0, 0, 0, 0, 0, 0);
+  VCMP_U8(2, v0, 3, 0, 0, 0, 0, 0, 0, 0);
+  VCMP_U8(3, v2, 0, 0, 0, 0, 0, 0, 0, 0);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vmsof.c
+++ b/apps/riscv-tests/isa/rv64uv/vmsof.c
@@ -9,18 +9,17 @@
 
 void TEST_CASE1() {
   VSET(8, e8, m1);
-  VLOAD_U8(v3, 8, 0, 0, 0, 0, 0, 0, 0);
+  VLOAD_8(v3, 8, 0, 0, 0, 0, 0, 0, 0);
   __asm__ volatile("vmsof.m v2, v3");
-  VEC_CMP_U8(1, v2, 8, 0, 0, 0, 0, 0, 0, 0);
+  VCMP_U8(1, v2, 8, 0, 0, 0, 0, 0, 0, 0);
 }
 
 void TEST_CASE2() {
   VSET(8, e8, m1);
-  VLOAD_U8(v3, 0, 0, 0, 1, 0, 0, 0, 0);
-  VLOAD_U8(v0, 3, 0, 0, 0, 0, 0, 0, 0);
-  CLEAR(v2);
+  VLOAD_8(v3, 0, 0, 0, 1, 0, 0, 0, 0);
+  VLOAD_8(v0, 3, 0, 0, 0, 0, 0, 0, 0);
   __asm__ volatile("vmsof.m v2, v3, v0.t");
-  VEC_CMP_U8(2, v2, 0, 0, 0, 0, 0, 0, 0, 0);
+  VCMP_U8(2, v2, 0, 0, 0, 0, 0, 0, 0, 0);
 }
 
 int main(void) {

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -122,7 +122,7 @@ package ara_pkg;
     // Integer add-with-carry and subtract-with-borrow carry-out instructions
     VMADC, VMSBC,
     // Mask operations
-    VMANDN, VMAND, VMOR, VMXOR, VMORN, VMNAND, VMNOR, VMXNOR,
+    VMANDN, VMAND, VMOR, VMXOR, VMORN, VMNAND, VMNOR, VMSBF, VMSOF, VMSIF, VIOTA, VID, VMXNOR,
     // Scalar moves from VRF
     VMVXS, VFMVFS,
     // Slide instructions

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -214,6 +214,8 @@ module ara import ara_pkg::*; #(
   strb_t     [NrLanes-1:0]                     masku_result_be;
   logic      [NrLanes-1:0]                     masku_result_gnt;
   logic      [NrLanes-1:0]                     masku_result_final_gnt;
+  elen_t     [NrLanes-1:0]                     alu_operand;
+  elen_t     [NrLanes-1:0]                     alu_operand_combined;
 
   for (genvar lane = 0; lane < NrLanes; lane++) begin: gen_lanes
     lane #(
@@ -226,6 +228,8 @@ module ara import ara_pkg::*; #(
       .scan_data_i                     (1'b0                                ),
       .scan_data_o                     (/* Unused */                        ),
       .lane_id_i                       (lane[idx_width(NrLanes)-1:0]        ),
+      // Mask instructions
+      .alu_operand_o                   (alu_operand[lane]                   ),
       // Interface with the dispatcher
       .vxsat_flag_o                    (vxsat_flag[lane]                    ),
       .alu_vxrm_i                      (alu_vxrm[lane]                      ),
@@ -394,12 +398,17 @@ module ara import ara_pkg::*; #(
   //  Mask unit  //
   /////////////////
 
+  for (genvar lane=0; lane<NrLanes; lane++) begin
+      assign alu_operand_combined [lane] = alu_operand [lane];
+  end
+
   masku #(
     .NrLanes(NrLanes),
     .vaddr_t(vaddr_t)
   ) i_masku (
     .clk_i                   (clk_i                           ),
     .rst_ni                  (rst_ni                          ),
+    .alu_operand_i           (alu_operand                     ),
     // Interface with the main sequencer
     .pe_req_i                (pe_req                          ),
     .pe_req_valid_i          (pe_req_valid                    ),

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -1018,6 +1018,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                   6'b001011: ara_req_d.op = ara_pkg::VASUB;
                   6'b010100: begin
                     ara_req_d.use_vd_op = 1'b1;
+                    ara_req_d.use_vs1   = 1'b0;
                     case (insn.varith_type.rs1)
                       5'b00001: ara_req_d.op = ara_pkg::VMSBF;
                       5'b00010: ara_req_d.op = ara_pkg::VMSOF;

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -1016,6 +1016,16 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                   6'b001001: ara_req_d.op = ara_pkg::VAADD;
                   6'b001010: ara_req_d.op = ara_pkg::VASUBU;
                   6'b001011: ara_req_d.op = ara_pkg::VASUB;
+                  6'b010100: begin
+                    ara_req_d.use_vd_op = 1'b1;
+                    case (insn.varith_type.rs1)
+                      5'b00001: ara_req_d.op = ara_pkg::VMSBF;
+                      5'b00010: ara_req_d.op = ara_pkg::VMSOF;
+                      5'b00011: ara_req_d.op = ara_pkg::VMSIF;
+                      5'b10000: ara_req_d.op = ara_pkg::VIOTA;
+                      5'b10001: ara_req_d.op = ara_pkg::VID;
+                    endcase
+                  end
                   6'b011000: begin
                     ara_req_d.op        = ara_pkg::VMANDN;
                     ara_req_d.use_vd_op = 1'b1;

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -30,6 +30,8 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     input  logic                                           scan_enable_i,
     input  logic                                           scan_data_i,
     output logic                                           scan_data_o,
+    // Mask instructions's operand
+    output elen_t                                          alu_operand_o,
     // Lane ID
     input  logic     [cf_math_pkg::idx_width(NrLanes)-1:0] lane_id_i,
     // Interface with the dispatcher
@@ -90,6 +92,8 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     input  logic                                           mask_valid_i,
     output logic                                           mask_ready_o
   );
+
+  assign alu_operand_o = alu_operand[1];
 
   /////////////////
   //  Spill Reg  //

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -120,7 +120,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
         VXOR, VREDXOR: res = operand_a_i ^ operand_b_i;
 
         // Mask logical operations
-        VMAND   : res = operand_b_i;
+        VMAND   : res = operand_b_i & operand_b_i;
         VMANDN  : res = ~operand_a_i & operand_b_i;
         VMNAND  : res = ~(operand_a_i & operand_b_i);
         VMOR    : res = operand_a_i | operand_b_i;

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -138,17 +138,6 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
                 end
             end
         end
-        VID : begin
-            for (int i = 0; i < (DataWidth); i = i + DataWidth) begin
-                res = i/DataWidth;
-            end
-        end
-        VIOTA : begin
-            for (int i = 0; i < DataWidth; i++) begin
-                res = res + operand_b_i[i];
-            end
-        end
-
         // Arithmetic instructions
         VSADDU: unique case (vew_i)
             EW8: for (int b = 0; b < 8; b++) begin

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -12,6 +12,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
     localparam int  unsigned StrbWidth = DataWidth/8,
     localparam type          strb_t    = logic [StrbWidth-1:0]
   ) (
+    input  pe_req_t    pe_req_i,
     input  elen_t      operand_a_i,
     input  elen_t      operand_b_i,
     input  logic       valid_i,
@@ -120,14 +121,34 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
         VXOR, VREDXOR: res = operand_a_i ^ operand_b_i;
 
         // Mask logical operations
-        VMAND   : res = operand_a_i & operand_b_i;
-        VMANDN: res = ~operand_a_i & operand_b_i;
+        VMAND   : res = operand_b_i;
+        VMANDN  : res = ~operand_a_i & operand_b_i;
         VMNAND  : res = ~(operand_a_i & operand_b_i);
         VMOR    : res = operand_a_i | operand_b_i;
         VMNOR   : res = ~(operand_a_i | operand_b_i);
-        VMORN : res = ~operand_a_i | operand_b_i;
+        VMORN   : res = ~operand_a_i | operand_b_i;
         VMXOR   : res = operand_a_i ^ operand_b_i;
         VMXNOR  : res = ~(operand_a_i ^ operand_b_i);
+        VMSBF, VMSIF, VMSOF : begin
+            for (int i = 0; i < DataWidth; i++) begin
+                if (operand_b_i[i] == 1'b0) begin
+                    res[i] = (op_i == VMSOF) ? 1'b0 : 1'b1;
+                end else begin
+                    res[i] = (op_i == VMSBF) ? 1'b0 : 1'b1;
+                    i = DataWidth + 1;
+                end
+            end
+        end
+        VID : begin
+            for (int i = 0; i < (pe_req_i.vl * DataWidth); i = i + DataWidth) begin
+                res = i/DataWidth;
+            end
+        end
+        VIOTA : begin
+            for (int i = 0; i < DataWidth; i++) begin
+                res = res + operand_b_i[i];
+            end
+        end
 
         // Arithmetic instructions
         VSADDU: unique case (vew_i)

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -12,7 +12,6 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
     localparam int  unsigned StrbWidth = DataWidth/8,
     localparam type          strb_t    = logic [StrbWidth-1:0]
   ) (
-    input  pe_req_t    pe_req_i,
     input  elen_t      operand_a_i,
     input  elen_t      operand_b_i,
     input  logic       valid_i,
@@ -140,7 +139,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
             end
         end
         VID : begin
-            for (int i = 0; i < (pe_req_i.vl * DataWidth); i = i + DataWidth) begin
+            for (int i = 0; i < (DataWidth); i = i + DataWidth) begin
                 res = i/DataWidth;
             end
         end

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -375,6 +375,8 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
         end
         [VMANDN:VMNOR]: alu_result = (masku_operand_a_i & bit_enable_mask) |
           (masku_operand_b_i & ~bit_enable_mask);
+        VMXNOR: alu_result = (masku_operand_a_i & bit_enable_mask) |
+          (masku_operand_b_i & ~bit_enable_mask);
         [VMFEQ:VMSBC] : begin
           automatic logic [ELEN*NrLanes-1:0] alu_result_flat = '0;
 

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -222,7 +222,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
   // Is the result queue empty?
   logic result_queue_empty;
   assign result_queue_empty = (result_queue_cnt_q == '0);
-  
+
   // viota variables
   elen_t [NrLanes-1:0]      alu_result_f;
   elen_t [NrLanes-1:0]      alu_result_ff;

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -373,7 +373,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
           alu_result [3] = 64'd30064771075 & {{24{1'b0}},{8{bit_enable_mask[7]}},{24{1'b0}},{8{bit_enable_mask[3]}}};
           be_id [3] = 8'b00010001;
         end
-        [VMANDN:VMNOR]: alu_result = (masku_operand_a_i & bit_enable_mask) |
+        [VMANDN:VMSIF]: alu_result = (masku_operand_a_i & bit_enable_mask) |
           (masku_operand_b_i & ~bit_enable_mask);
         VMXNOR: alu_result = (masku_operand_a_i & bit_enable_mask) |
           (masku_operand_b_i & ~bit_enable_mask);


### PR DESCRIPTION
Add RTL and updated tests for vmsbf, vmsof, vmsif, vid and viota mask instructions

## Changelog

### Fixed

- N/A

### Added

- Added RTL for vmsbf, vmsof, vmsif, vid and viota mask instructions

### Changed
- Updated tests for vmsbf, vmsof, vmsif, vid and viota mask instructions

## Checklist

- [ ] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
