### PR TITLE
Add support for vmsbf, vmsof, vmsif, viota, vid, vrgather, vrgatherei16 and vcompress instructions

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -41,6 +41,8 @@ sources:
     - hardware/src/lane/simd_mul.sv
     - hardware/src/lane/vector_regfile.sv
     - hardware/src/masku/masku.sv
+    - hardware/src/masku/seq_modules/op_seq.sv
+    - hardware/src/masku/seq_modules/res_seq.sv
     - hardware/src/sldu/sldu.sv
     - hardware/src/vlsu/addrgen.sv
     - hardware/src/vlsu/vldu.sv

--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -161,6 +161,9 @@ rv64uv_sc_tests = vaadd \
                   vssrl \
                   vnclip \
                   vnclipu
+                  vrgather \
+                  vrgatherei16 \
+                  vcompress
 
 #rv64uv_sc_tests = vaadd vaaddu vadc vasub vasubu vcompress vfclass vfdiv vfirst vfrdiv vfsqrt vid viota vl vlff vl_nocheck vlx vmsbf vmsif vmsof vpopc_m vrgather vsadd vsaddu vsetvl vsetivli vsetvli vsmul vssra vssrl vssub vssubu vsux vsx
 

--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -150,10 +150,6 @@ rv64uv_sc_tests = vaadd \
                   vss \
                   vsuxei \
                   vsetivli \
-                  misa_v \
-                  mstatus_vs \
-                  vxsat \
-                  vxrm \
                   vmsbf \
                   vmsof \
                   vmsif \

--- a/apps/riscv-tests/isa/rv64uv/vcompress.c
+++ b/apps/riscv-tests/isa/rv64uv/vcompress.c
@@ -13,7 +13,7 @@ void TEST_CASE1() {
   VLOAD_64(v0, 12, 0, 0, 0);
   VCLEAR(v2);
   __asm__ volatile("vcompress.vm v2, v4, v0");
-  //DEBUG_64(v2);
+  // DEBUG_64(v2);
   VCMP_I64(1, v2, 3, 4, 0, 0);
 }
 

--- a/apps/riscv-tests/isa/rv64uv/vcompress.c
+++ b/apps/riscv-tests/isa/rv64uv/vcompress.c
@@ -11,10 +11,10 @@ void TEST_CASE1() {
   VSET(4, e64, m1);
   VLOAD_64(v4, 1, 2, 3, 4);
   VLOAD_64(v0, 12, 0, 0, 0);
-  CLEAR(v2);
+  VCLEAR(v2);
   __asm__ volatile("vcompress.vm v2, v4, v0");
-  DEBUG_64(v2);
-  VEC_CMP_64(1, v2, 3, 4, 0, 0);
+  //DEBUG_64(v2);
+  VCMP_I64(1, v2, 3, 4, 0, 0);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vid.c
+++ b/apps/riscv-tests/isa/rv64uv/vid.c
@@ -8,13 +8,13 @@
 #include "vector_macros.h"
 
 void TEST_CASE1() {
-  VSET(8, e8, m1);
+  VSET(16, e8, m1);
   __asm__ volatile("vid.v v1");
   VCMP_U8(1, v1, 0, 1, 2, 3, 4, 5, 6, 7);
 }
 
 void TEST_CASE2() {
-  VSET(8, e8, m1);
+  VSET(16, e8, m1);
   VLOAD_8(v0, 85, 0, 0, 0, 0, 0, 0, 0);
   VCLEAR(v1);
   __asm__ volatile("vid.v v1, v0.t");

--- a/apps/riscv-tests/isa/rv64uv/viota.c
+++ b/apps/riscv-tests/isa/rv64uv/viota.c
@@ -8,20 +8,20 @@
 #include "vector_macros.h"
 
 void TEST_CASE1() {
-  VSET(8, e8, m1);
+  VSET(16, e8, m1);
   VLOAD_8(v1, 1, 0, 0, 1, 0, 0, 0, 1);
   __asm__ volatile("viota.m v2, v1");
   VCMP_U8(1, v2, 0, 1, 1, 1, 2, 2, 2, 2);
 }
 
 void TEST_CASE2() {
-  VSET(8, e8, m1);
+  VSET(16, e8, m1);
   VLOAD_8(v1, 1, 0, 0, 1, 0, 0, 0, 1);
   VLOAD_8(v0, 199, 0, 0, 0, 0, 0, 0, 0);
   VCLEAR(v2);
   __asm__ volatile("viota.m v2, v1, v0.t");
   VCMP_U8(2, v0, 199, 0, 0, 0, 0, 0, 0, 0);
-  VCMP_U8(3, v2, 0, 1, 0, 0, 0, 1, 1, 1);
+  VCMP_U8(3, v2, 0, 1, 1, 0, 0, 0, 1, 1);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vmsbf.c
+++ b/apps/riscv-tests/isa/rv64uv/vmsbf.c
@@ -8,7 +8,7 @@
 #include "vector_macros.h"
 
 void TEST_CASE1() {
-  VSET(8, e8, m1);
+  VSET(16, e8, m1);
   VLOAD_8(v3, 8, 0, 0, 0, 0, 0, 0, 0);
   VCLEAR(v2);
   __asm__ volatile("vmsbf.m v2, v3");
@@ -16,7 +16,7 @@ void TEST_CASE1() {
 }
 
 void TEST_CASE2() {
-  VSET(8, e8, m1);
+  VSET(16, e8, m1);
   VLOAD_8(v3, 8, 0, 0, 0, 0, 0, 0, 0);
   VLOAD_8(v0, 3, 0, 0, 0, 0, 0, 0, 0);
   VCLEAR(v2);

--- a/apps/riscv-tests/isa/rv64uv/vmsif.c
+++ b/apps/riscv-tests/isa/rv64uv/vmsif.c
@@ -8,14 +8,14 @@
 #include "vector_macros.h"
 
 void TEST_CASE1() {
-  VSET(8, e8, m1);
+  VSET(16, e8, m1);
   VLOAD_8(v3, 8, 0, 0, 0, 0, 0, 0, 0);
   __asm__ volatile("vmsif.m v2, v3");
   VCMP_U8(1, v2, 15, 0, 0, 0, 0, 0, 0, 0);
 }
 
 void TEST_CASE2() {
-  VSET(8, e8, m1);
+  VSET(16, e8, m1);
   VLOAD_8(v3, 8, 0, 0, 0, 0, 0, 0, 0);
   VLOAD_8(v0, 11, 0, 0, 0, 0, 0, 0, 0);
   VCLEAR(v2);

--- a/apps/riscv-tests/isa/rv64uv/vmsof.c
+++ b/apps/riscv-tests/isa/rv64uv/vmsof.c
@@ -8,14 +8,14 @@
 #include "vector_macros.h"
 
 void TEST_CASE1() {
-  VSET(8, e8, m1);
+  VSET(16, e8, m1);
   VLOAD_8(v3, 8, 0, 0, 0, 0, 0, 0, 0);
   __asm__ volatile("vmsof.m v2, v3");
   VCMP_U8(1, v2, 8, 0, 0, 0, 0, 0, 0, 0);
 }
 
 void TEST_CASE2() {
-  VSET(8, e8, m1);
+  VSET(16, e8, m1);
   VLOAD_8(v3, 0, 0, 0, 1, 0, 0, 0, 0);
   VLOAD_8(v0, 3, 0, 0, 0, 0, 0, 0, 0);
   VCLEAR(v2);

--- a/apps/riscv-tests/isa/rv64uv/vrgather.c
+++ b/apps/riscv-tests/isa/rv64uv/vrgather.c
@@ -12,51 +12,58 @@ void TEST_CASE1() {
   VLOAD_8(v4, 10, 20, 30, 40, 50);
   VLOAD_8(v6, 1, 0, 4, 3, 2);
   __asm__ volatile("vrgather.vv v2, v4, v6");
-  VEC_CMP_8(1, v2, 20, 10, 50, 40, 30);
+  VCMP_U8(1, v2, 20, 10, 50, 40, 30);
 }
 
 void TEST_CASE2() {
   VSET(5, e8, m1);
   VLOAD_8(v4, 10, 20, 30, 40, 50);
   VLOAD_8(v6, 1, 0, 4, 3, 2);
-  VLOAD_U8(v0, 26, 0, 0, 0, 0);
-  CLEAR(v2);
+  VCLEAR(v0);
+  VLOAD_8(v0, 26, 0, 0, 0, 0);
+  VCLEAR(v2);
   __asm__ volatile("vrgather.vv v2, v4, v6, v0.t");
-  VEC_CMP_8(2, v2, 0, 10, 0, 40, 30);
+  VCMP_U8(2, v0, 26, 0, 0, 0, 0);
+  VCMP_U8(2, v2, 0, 10, 0, 40, 30);
 }
 
 void TEST_CASE3() {
   VSET(5, e8, m1);
   VLOAD_8(v4, 10, 20, 30, 40, 50);
   uint64_t scalar = 3;
+  VCLEAR(v2);
   __asm__ volatile("vrgather.vx v2, v4, %[A]" ::[A] "r"(scalar));
-  VEC_CMP_8(3, v2, 40, 40, 40, 40, 40);
+  VCMP_U8(3, v2, 40, 40, 40, 40, 40);
 }
 
 void TEST_CASE4() {
   VSET(5, e8, m1);
   VLOAD_8(v4, 10, 20, 30, 40, 50);
   uint64_t scalar = 3;
-  VLOAD_U8(v0, 7, 0, 0, 0, 0);
-  CLEAR(v2);
+  VCLEAR(v0);
+  VLOAD_8(v0, 7, 0, 0, 0, 0);
+  VCLEAR(v2);
   __asm__ volatile("vrgather.vx v2, v4, %[A], v0.t" ::[A] "r"(scalar));
-  VEC_CMP_8(4, v2, 40, 40, 40, 0, 0);
+  VCMP_U8(4, v0, 7, 0, 0, 0, 0);
+  VCMP_U8(4, v2, 40, 40, 40, 0, 0);
 }
 
 void TEST_CASE5() {
   VSET(5, e8, m1);
   VLOAD_8(v4, 10, 20, 30, 40, 50);
   __asm__ volatile("vrgather.vi v2, v4, 3");
-  VEC_CMP_8(5, v2, 40, 40, 40, 40, 40);
+  VCMP_U8(5, v2, 40, 40, 40, 40, 40);
 }
 
 void TEST_CASE6() {
   VSET(5, e8, m1);
   VLOAD_8(v4, 10, 20, 30, 40, 50);
-  VLOAD_U8(v0, 7, 0, 0, 0, 0);
-  CLEAR(v2);
+  VCLEAR(v0);
+  VLOAD_8(v0, 7, 0, 0, 0, 0);
+  VCLEAR(v2);
   __asm__ volatile("vrgather.vi v2, v4, 3, v0.t");
-  VEC_CMP_8(6, v2, 40, 40, 40, 0, 0);
+  VCMP_U8(6, v0, 7, 0, 0, 0, 0);
+  VCMP_U8(6, v2, 40, 40, 40, 0, 0);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vrgatherei16.c
+++ b/apps/riscv-tests/isa/rv64uv/vrgatherei16.c
@@ -1,0 +1,35 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Muhammad Ijaz
+
+#include "vector_macros.h"
+
+void TEST_CASE1() {
+  VSET(5, e16, m2);
+  VLOAD_8(v6, 1, 0, 4, 3, 2);
+  VSET(5, e8, m1);
+  VLOAD_8(v4, 10, 20, 30, 40, 50);
+  __asm__ volatile("vrgatherei16.vv v2, v4, v6");
+  VCMP_U8(1, v2, 20, 10, 50, 40, 30);
+}
+void TEST_CASE2() {
+  VSET(5, e16, m2);
+  VLOAD_8(v6, 1, 0, 4, 3, 2);
+  VSET(5, e8, m1);
+  VLOAD_8(v4, 10, 20, 30, 40, 50);
+  VLOAD_8(v0, 26, 0, 0, 0, 0);
+  VCLEAR(v2);
+  __asm__ volatile("vrgatherei16.vv v2, v4, v6, v0.t");
+  VCMP_U8(2, v0, 26, 0, 0, 0, 0);
+  VCMP_U8(3, v2, 0, 10, 0, 40, 30);
+}
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+  TEST_CASE1();
+  TEST_CASE2();
+  EXIT_CHECK();
+}

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -127,7 +127,7 @@ package ara_pkg;
     // Integer add-with-carry and subtract-with-borrow carry-out instructions
     VMADC, VMSBC,
     // Mask operations
-    VMANDNOT, VMAND, VMOR, VMXOR, VMORNOT, VMNAND, VMNOR, VMSBF, VMSOF, VMSIF, VIOTA, VID, VMXNOR,
+    VMANDN, VMAND, VMOR, VMXOR, VMORN, VMNAND, VMNOR, VMSBF, VMSOF, VMSIF, VIOTA, VID, VMXNOR,
     // Scalar moves from VRF
     VMVXS, VFMVFS,
     // Slide instructions

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -127,7 +127,7 @@ package ara_pkg;
     // Integer add-with-carry and subtract-with-borrow carry-out instructions
     VMADC, VMSBC,
     // Mask operations
-    VMANDN, VMAND, VMOR, VMXOR, VMORN, VMNAND, VMNOR, VMSBF, VMSOF, VMSIF, VIOTA, VID, VMXNOR,
+    VMANDNOT, VMAND, VMOR, VMXOR, VMORNOT, VMNAND, VMNOR, VMSBF, VMSOF, VMSIF, VIOTA, VID, VMXNOR,
     // Scalar moves from VRF
     VMVXS, VFMVFS,
     // Slide instructions

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -127,7 +127,7 @@ package ara_pkg;
     // Integer add-with-carry and subtract-with-borrow carry-out instructions
     VMADC, VMSBC,
     // Mask operations
-    VMANDN, VMAND, VMOR, VMXOR, VMORN, VMNAND, VMNOR, VMSBF, VMSOF, VMSIF, VIOTA, VID, VMXNOR,
+    VMANDN, VMAND, VMOR, VMXOR, VMORN, VMNAND, VMNOR, VMSBF, VMSOF, VMSIF, VIOTA, VID, VRGATHER, VRGATHEREI16, VCOMPRESS, VMXNOR,
     // Scalar moves from VRF
     VMVXS, VFMVFS,
     // Slide instructions

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -147,6 +147,10 @@ module ara import ara_pkg::*; #(
   // Interface with the Mask Unit
   elen_t                        result_scalar;
   logic                         result_scalar_valid;
+  elen_t     [NrLanes-1:0]                     alu_operand;
+  logic      [NrLanes-1:0]                     alu_operand_valid;
+  elen_t     [NrLanes-1:0]                     viota_operand;
+  logic      [NrLanes-1:0]                     viota_operand_valid;
 
   ara_sequencer #(.NrLanes(NrLanes)) i_sequencer (
     .clk_i                 (clk_i                    ),
@@ -206,18 +210,6 @@ module ara import ara_pkg::*; #(
   logic                                        addrgen_operand_ready;
   logic      [NrLanes-1:0]                     sldu_red_valid;
 
-  // Mask unit operands
-  elen_t     [NrLanes-1:0][NrMaskFUnits+2-1:0] masku_operand;
-  logic      [NrLanes-1:0][NrMaskFUnits+2-1:0] masku_operand_valid;
-  logic      [NrLanes-1:0][NrMaskFUnits+2-1:0] masku_operand_ready;
-  strb_t     [NrLanes-1:0]                     mask;
-  logic      [NrLanes-1:0]                     mask_valid;
-  logic                                        mask_valid_lane;
-  logic      [NrLanes-1:0]                     lane_mask_ready;
-  elen_t     [NrLanes-1:0]                     alu_operand;
-  logic      [NrLanes-1:0]                     alu_operand_valid;
-  elen_t     [NrLanes-1:0]                     viota_operand;
-  logic      [NrLanes-1:0]                     viota_operand_valid;
   // Results
   // Load Unit
   logic      [NrLanes-1:0]                     ldu_result_req;

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -145,12 +145,10 @@ module ara import ara_pkg::*; #(
   logic                                        mask_valid_lane;
   logic      [NrLanes-1:0]                     lane_mask_ready;
   // Interface with the Mask Unit
-  elen_t                        result_scalar;
-  logic                         result_scalar_valid;
-  elen_t     [NrLanes-1:0]                     alu_operand;
-  logic      [NrLanes-1:0]                     alu_operand_valid;
-  elen_t     [NrLanes-1:0]                     viota_operand;
-  logic      [NrLanes-1:0]                     viota_operand_valid;
+  elen_t                                       result_scalar;
+  logic                                        result_scalar_valid;
+  elen_t     [NrLanes-1:0]                     viota_operand, alu_operand_a, alu_operand_b;
+  logic      [NrLanes-1:0]                     viota_operand_valid, alu_operand_a_valid, alu_operand_b_valid;
 
   ara_sequencer #(.NrLanes(NrLanes)) i_sequencer (
     .clk_i                 (clk_i                    ),
@@ -303,8 +301,10 @@ module ara import ara_pkg::*; #(
       .mask_i                          (mask[lane]                          ),
       .mask_valid_i                    (mask_valid[lane] & mask_valid_lane  ),
       .mask_ready_o                    (lane_mask_ready[lane]               ),
-      .alu_operand_o                   (alu_operand[lane]                   ),
-      .alu_operand_valid_o             (alu_operand_valid[lane]             ),
+      .alu_operand_a_o                 (alu_operand_a[lane]                 ),
+      .alu_operand_a_valid_o           (alu_operand_a_valid[lane]           ),
+      .alu_operand_b_o                 (alu_operand_b[lane]                 ),
+      .alu_operand_b_valid_o           (alu_operand_b_valid[lane]           ),
       .viota_operand_o                 (viota_operand[lane]                 ),
       .viota_operand_valid_o           (viota_operand_valid[lane]           )
     );
@@ -444,8 +444,10 @@ module ara import ara_pkg::*; #(
     .masku_result_be_o       (masku_result_be                 ),
     .masku_result_gnt_i      (masku_result_gnt                ),
     .masku_result_final_gnt_i(masku_result_final_gnt          ),
-    .alu_operand_i           (alu_operand                     ),
-    .alu_operand_valid_i     (alu_operand_valid               ),
+    .alu_operand_a_i         (alu_operand_a                   ),
+    .alu_operand_a_valid_i   (alu_operand_a_valid             ),
+    .alu_operand_b_i         (alu_operand_b                   ),
+    .alu_operand_b_valid_i   (alu_operand_b_valid             ),
     .viota_operand_i         (viota_operand                   ),
     .viota_operand_valid_i   (viota_operand_valid             ),
     // Interface with the VFUs

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -233,6 +233,7 @@ module ara import ara_pkg::*; #(
   logic      [NrLanes-1:0]                     masku_result_final_gnt;
   elen_t     [NrLanes-1:0]                     alu_operand;
   elen_t     [NrLanes-1:0]                     alu_operand_combined;
+  logic      [NrLanes-1:0]                     alu_operand_valid;
 
   for (genvar lane = 0; lane < NrLanes; lane++) begin: gen_lanes
     lane #(
@@ -247,6 +248,7 @@ module ara import ara_pkg::*; #(
       .lane_id_i                       (lane[idx_width(NrLanes)-1:0]        ),
       // Mask instructions
       .alu_operand_o                   (alu_operand[lane]                   ),
+      .alu_operand_valid_o             (alu_operand_valid[lane]             ),
       // Interface with the dispatcher
       .vxsat_flag_o                    (vxsat_flag[lane]                    ),
       .alu_vxrm_i                      (alu_vxrm[lane]                      ),
@@ -426,6 +428,7 @@ module ara import ara_pkg::*; #(
     .clk_i                   (clk_i                           ),
     .rst_ni                  (rst_ni                          ),
     .alu_operand_i           (alu_operand                     ),
+    .alu_operand_valid_i     (alu_operand_valid               ),
     // Interface with the main sequencer
     .pe_req_i                (pe_req                          ),
     .pe_req_valid_i          (pe_req_valid                    ),

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -1087,10 +1087,6 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                       ara_req_valid_d   = 1'b0;
                     end
                   end
-                  6'b001000: ara_req_d.op = ara_pkg::VAADDU;
-                  6'b001001: ara_req_d.op = ara_pkg::VAADD;
-                  6'b001010: ara_req_d.op = ara_pkg::VASUBU;
-                  6'b001011: ara_req_d.op = ara_pkg::VASUB;
                   6'b010100: begin
                     ara_req_d.use_vd_op = 1'b1;
                     ara_req_d.use_vs1   = 1'b0;

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -417,6 +417,8 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                   6'b001001: ara_req_d.op = ara_pkg::VAND;
                   6'b001010: ara_req_d.op = ara_pkg::VOR;
                   6'b001011: ara_req_d.op = ara_pkg::VXOR;
+                  6'b001100: ara_req_d.op = ara_pkg::VRGATHER;
+                  6'b001110: ara_req_d.op = ara_pkg::VRGATHEREI16;
                   6'b010000: begin
                     ara_req_d.op = ara_pkg::VADC;
 
@@ -618,6 +620,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                   6'b001001: ara_req_d.op = ara_pkg::VAND;
                   6'b001010: ara_req_d.op = ara_pkg::VOR;
                   6'b001011: ara_req_d.op = ara_pkg::VXOR;
+                  6'b001100: ara_req_d.op = ara_pkg::VRGATHER;
                   6'b001110: begin
                     ara_req_d.op            = ara_pkg::VSLIDEUP;
                     ara_req_d.stride        = acc_req_i.rs1;
@@ -814,6 +817,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                   6'b001001: ara_req_d.op = ara_pkg::VAND;
                   6'b001010: ara_req_d.op = ara_pkg::VOR;
                   6'b001011: ara_req_d.op = ara_pkg::VXOR;
+                  6'b001100: ara_req_d.op = ara_pkg::VRGATHER;
                   6'b101010: ara_req_d.op = ara_pkg::VSSRL;
                   6'b101110: ara_req_d.op = ara_pkg::VNCLIPU;
                   6'b101111: ara_req_d.op = ara_pkg::VNCLIP;
@@ -1151,6 +1155,9 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                       end
                       default: illegal_insn = 1'b1;
                     endcase
+                  6'b010111: begin
+                    ara_req_d.use_vd_op = 1'b1;
+                    ara_req_d.op        = ara_pkg::VCOMPRESS;
                   end
                   6'b011000: begin
                     ara_req_d.op        = ara_pkg::VMANDN;

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -1087,6 +1087,10 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                       ara_req_valid_d   = 1'b0;
                     end
                   end
+                  6'b001000: ara_req_d.op = ara_pkg::VAADDU;
+                  6'b001001: ara_req_d.op = ara_pkg::VAADD;
+                  6'b001010: ara_req_d.op = ara_pkg::VASUBU;
+                  6'b001011: ara_req_d.op = ara_pkg::VASUB;
                   6'b010100: begin
                     ara_req_d.use_vd_op = 1'b1;
                     ara_req_d.use_vs1   = 1'b0;

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -97,9 +97,30 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     output logic                                           mask_ready_o
   );
 
+  //////////////////////
+  //  Scalar operand  //
+  //////////////////////
+
+  elen_t scalar_op;
+
+  // Replicate the scalar operand on the 64-bit word, depending
+  // on the element width.
+  always_comb begin
+    // Default assignment
+    scalar_op = '0;
+
+    case (vfu_operation.vtype.vsew)
+      EW64: scalar_op = {1{vfu_operation.scalar_op[63:0]}};
+      EW32: scalar_op = {2{vfu_operation.scalar_op[31:0]}};
+      EW16: scalar_op = {4{vfu_operation.scalar_op[15:0]}};
+      EW8 : scalar_op = {8{vfu_operation.scalar_op[ 7:0]}};
+      default:;
+    endcase
+  end
+
   // Getting operand for vmsbf, vmsif, vmsof, viota and vid mask instructions + vrgather instruction
-  assign alu_operand_a_o         = alu_operand[0];
-  assign alu_operand_a_valid_o   = alu_operand_valid[0];
+  assign alu_operand_a_o         = (vfu_operation.use_scalar_op) ? scalar_op : alu_operand[0];
+  assign alu_operand_a_valid_o   = (vfu_operation.use_scalar_op) ? (vfu_operation.use_scalar_op & scalar_op) : alu_operand_valid[0];
   assign alu_operand_b_o         = alu_operand[1];
   assign alu_operand_b_valid_o   = alu_operand_valid[1];
   assign viota_operand_o         = alu_result_wdata;

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -30,9 +30,6 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     input  logic                                           scan_enable_i,
     input  logic                                           scan_data_i,
     output logic                                           scan_data_o,
-    // Mask instructions's operand
-    output elen_t                                          alu_operand_o,
-    output logic                                           alu_operand_valid_o,
     // Lane ID
     input  logic     [cf_math_pkg::idx_width(NrLanes)-1:0] lane_id_i,
     // Interface with the dispatcher
@@ -88,14 +85,21 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     input  strb_t                                          masku_result_be_i,
     output logic                                           masku_result_gnt_o,
     output logic                                           masku_result_final_gnt_o,
+    output elen_t                                          alu_operand_o,
+    output logic                                           alu_operand_valid_o,
+    output elen_t                                          viota_operand_o,
+    output logic                                           viota_operand_valid_o,
     // Interface between the Mask unit and the VFUs
     input  strb_t                                          mask_i,
     input  logic                                           mask_valid_i,
     output logic                                           mask_ready_o
   );
 
-  assign alu_operand_o = alu_operand[1];
-  assign alu_operand_valid_o = alu_operand_valid[1];
+  // Getting operand for vmsbf, vmsif, vmsof, viota and vid mask instructions
+  assign alu_operand_o         = alu_operand[1];
+  assign alu_operand_valid_o   = alu_operand_valid[1];
+  assign viota_operand_o       = alu_result_wdata;
+  assign viota_operand_valid_o = |alu_result_be;
 
   /////////////////
   //  Spill Reg  //

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -85,8 +85,10 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     input  strb_t                                          masku_result_be_i,
     output logic                                           masku_result_gnt_o,
     output logic                                           masku_result_final_gnt_o,
-    output elen_t                                          alu_operand_o,
-    output logic                                           alu_operand_valid_o,
+    output elen_t                                          alu_operand_a_o,
+    output elen_t                                          alu_operand_b_o,
+    output logic                                           alu_operand_a_valid_o,
+    output logic                                           alu_operand_b_valid_o,
     output elen_t                                          viota_operand_o,
     output logic                                           viota_operand_valid_o,
     // Interface between the Mask unit and the VFUs
@@ -95,11 +97,13 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     output logic                                           mask_ready_o
   );
 
-  // Getting operand for vmsbf, vmsif, vmsof, viota and vid mask instructions
-  assign alu_operand_o         = alu_operand[1];
-  assign alu_operand_valid_o   = alu_operand_valid[1];
-  assign viota_operand_o       = alu_result_wdata;
-  assign viota_operand_valid_o = |alu_result_be;
+  // Getting operand for vmsbf, vmsif, vmsof, viota and vid mask instructions + vrgather instruction
+  assign alu_operand_a_o         = alu_operand[0];
+  assign alu_operand_a_valid_o   = alu_operand_valid[0];
+  assign alu_operand_b_o         = alu_operand[1];
+  assign alu_operand_b_valid_o   = alu_operand_valid[1];
+  assign viota_operand_o         = alu_result_wdata;
+  assign viota_operand_valid_o   = |alu_result_be;
 
   /////////////////
   //  Spill Reg  //

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -32,6 +32,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     output logic                                           scan_data_o,
     // Mask instructions's operand
     output elen_t                                          alu_operand_o,
+    output logic                                           alu_operand_valid_o,
     // Lane ID
     input  logic     [cf_math_pkg::idx_width(NrLanes)-1:0] lane_id_i,
     // Interface with the dispatcher
@@ -94,6 +95,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
   );
 
   assign alu_operand_o = alu_operand[1];
+  assign alu_operand_valid_o = alu_operand_valid[1];
 
   /////////////////
   //  Spill Reg  //

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -128,16 +128,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
         VMORN   : res = ~operand_a_i | operand_b_i;
         VMXOR   : res = operand_a_i ^ operand_b_i;
         VMXNOR  : res = ~(operand_a_i ^ operand_b_i);
-        VMSBF, VMSIF, VMSOF : begin
-            for (int i = 0; i < DataWidth; i++) begin
-                if (operand_b_i[i] == 1'b0) begin
-                    res[i] = (op_i == VMSOF) ? 1'b0 : 1'b1;
-                end else begin
-                    res[i] = (op_i == VMSBF) ? 1'b0 : 1'b1;
-                    i = DataWidth + 1;
-                end
-            end
-        end
+
         // Arithmetic instructions
         VSADDU: unique case (vew_i)
             EW8: for (int b = 0; b < 8; b++) begin
@@ -176,14 +167,6 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
                 automatic logic [32:0] sum = opa.w32[b] + opb.w32[b];
                 vxsat.w32[b]   = {4{(sum[31] ^ opa.w32[b][31]) && !(opa.w32[b][31] ^ opb.w32[b][31])}};
                 res.w32[b]     = &vxsat.w32[b] ? (sum[31] ? {1'b0, {31{1'b1}}} : {1'b1, {31{1'b0}}} ) : sum[31:0];
-              end
-            EW64: for (int b = 0; b < 1; b++) begin
-                automatic logic [64:0] sum = opa.w64[b] + opb.w64[b];
-                vxsat.w64[b]   = {8{(sum[63] ^ opa.w64[b][63]) & ~(opa.w64[b][63] ^ opb.w64[b][63])}};
-                res.w64[b]     = &vxsat.w64[b] ? (sum[63] ? {1'b0, {63{1'b1}}} : {1'b1, {63{1'b0}}} ) : sum[63:0];
-              end
-          endcase
-        VAADD, VAADDU: unique case (vew_i)
             EW8: for (int b = 0; b < 8; b++) begin
               automatic logic [ 8:0] sum = opa.w8 [b] + opb.w8 [b];
                 unique case (vxrm)

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -129,6 +129,34 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
         VMXOR   : res = operand_a_i ^ operand_b_i;
         VMXNOR  : res = ~(operand_a_i ^ operand_b_i);
 
+        // viota and vid mask instructions
+        VIOTA: unique case (vew_i)
+            EW8: for (int b = 0; b < 8; b++) begin
+              res.w8[b] = '0;
+                for (int i = b * 8; i < (b * 8)+7; i++) begin
+                  res.w8[b] += operand_b_i [i];
+                end
+              end
+            EW16: for (int b = 0; b < 4; b++) begin
+              res.w8[b] = '0;
+                for (int i = b * 16; i < (b * 16)+15; i++) begin
+                  res.w8[b] += operand_b_i [i];
+                end
+              end
+            EW32: for (int b = 0; b < 2; b++) begin
+              res.w8[b] = '0;
+                for (int i = b * 32; i < (b * 32)+31; i++) begin
+                  res.w8[b] += operand_b_i [i];
+                end
+              end
+            EW64: for (int b = 0; b < 1; b++) begin
+              res.w8[b] = '0;
+                for (int i = b * 64; i < (b * 64)+63; i++) begin
+                  res.w8[b] += operand_b_i [i];
+                end
+              end
+        endcase
+
         // Arithmetic instructions
         VSADDU: unique case (vew_i)
             EW8: for (int b = 0; b < 8; b++) begin

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -121,11 +121,11 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
 
         // Mask logical operations
         VMAND   : res = operand_a_i & operand_b_i;
-        VMANDNOT: res = ~operand_a_i & operand_b_i;
+        VMANDN: res = ~operand_a_i & operand_b_i;
         VMNAND  : res = ~(operand_a_i & operand_b_i);
         VMOR    : res = operand_a_i | operand_b_i;
         VMNOR   : res = ~(operand_a_i | operand_b_i);
-        VMORNOT : res = ~operand_a_i | operand_b_i;
+        VMORN : res = ~operand_a_i | operand_b_i;
         VMXOR   : res = operand_a_i ^ operand_b_i;
         VMXNOR  : res = ~(operand_a_i ^ operand_b_i);
 
@@ -236,7 +236,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
                 res.w64[b] = (op_i == VAADDU) ? sum[64:1] + r : {sum[63], sum[63:1]} + r;
               end
           endcase
-          VADD, VADC, VMADC, VREDSUM, VWREDSUMU, VWREDSUM: unique case (vew_i)
+        VADD, VADC, VMADC, VREDSUM, VWREDSUMU, VWREDSUM: unique case (vew_i)
             EW8: for (int b = 0; b < 8; b++) begin
                 automatic logic [ 8:0] sum = opa.w8 [b] + opb.w8 [b] +
                 logic'(op_i inside {VADC, VMADC} && mask_i[1*b] & ~vm_i);

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -121,11 +121,11 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
 
         // Mask logical operations
         VMAND   : res = operand_a_i & operand_b_i;
-        VMANDN  : res = ~operand_a_i & operand_b_i;
+        VMANDNOT: res = ~operand_a_i & operand_b_i;
         VMNAND  : res = ~(operand_a_i & operand_b_i);
         VMOR    : res = operand_a_i | operand_b_i;
         VMNOR   : res = ~(operand_a_i | operand_b_i);
-        VMORN   : res = ~operand_a_i | operand_b_i;
+        VMORNOT : res = ~operand_a_i | operand_b_i;
         VMXOR   : res = operand_a_i ^ operand_b_i;
         VMXNOR  : res = ~(operand_a_i ^ operand_b_i);
 

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -310,6 +310,10 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
   logic         [DataWidth-1:0]                           vfirst_count;
   // vmsbf, vmsof and vmsif variables
   logic         [NrLanes*DataWidth-1:0]                 alu_result_mask;
+  elen_t [NrLanes-1:0]      alu_result;
+  logic  [NrLanes*ELEN-1:0] bit_enable;
+  logic  [NrLanes*ELEN-1:0] bit_enable_shuffle;
+  logic  [NrLanes*ELEN-1:0] bit_enable_mask;
 
   // Pointers
   //
@@ -644,7 +648,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
 
       // Evaluate the instruction
       unique case (vinsn_issue.op) inside
-        [VMANDN:VMXNOR]: alu_result = (masku_operand_a_i & bit_enable_mask) |
+        [VMANDNOT:VMNOR]: alu_result = (masku_operand_a_i & bit_enable_mask) |
           (masku_operand_b_i & ~bit_enable_mask);
         [VMSBF:VMSIF] : begin
           if (alu_operand_valid_i) begin
@@ -658,8 +662,6 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
               end
           end
         end
-        [VMANDN:VMSIF]: alu_result = (masku_operand_a_i & bit_enable_mask) |
-          (masku_operand_b_i & ~bit_enable_mask);
         VMXNOR: alu_result = (masku_operand_a_i & bit_enable_mask) |
           (masku_operand_b_i & ~bit_enable_mask);
         VIOTA: begin

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -32,8 +32,6 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
   ) (
     input  logic                                       clk_i,
     input  logic                                       rst_ni,
-    input  logic [DataWidth*NrLanes-1:0]               alu_operand_i,
-    input  logic [NrLanes-1:0]                         alu_operand_valid_i,
     // Interface with the main sequencer
     input  pe_req_t                                    pe_req_i,
     input  logic                                       pe_req_valid_i,
@@ -53,6 +51,10 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
     output strb_t    [NrLanes-1:0]                     masku_result_be_o,
     input  logic     [NrLanes-1:0]                     masku_result_gnt_i,
     input  logic     [NrLanes-1:0]                     masku_result_final_gnt_i,
+    input  logic     [DataWidth*NrLanes-1:0]           alu_operand_i,
+    input  logic     [NrLanes-1:0]                     alu_operand_valid_i,
+    input  logic     [DataWidth*NrLanes-1:0]           viota_operand_i,
+    input  logic     [NrLanes-1:0]                     viota_operand_valid_i,
     // Interface with the VFUs
     output strb_t    [NrLanes-1:0]                     mask_o,
     output logic     [NrLanes-1:0]                     mask_valid_o,
@@ -64,8 +66,6 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
   );
 
   import cf_math_pkg::idx_width;
-
-  logic [NrLanes*DataWidth-1:0] alu_operand_seq;
 
   ////////////////
   //  Operands  //
@@ -232,9 +232,13 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
   logic result_queue_empty;
   assign result_queue_empty = (result_queue_cnt_q == '0);
 
-  // viota variables
-  elen_t [NrLanes-1:0]      alu_result_f;
-  elen_t [NrLanes-1:0]      alu_result_ff;
+  // vmsbf, vmsif, vmsof, viota, vid variables
+  elen_t [NrLanes-1:0]           alu_result_f;
+  elen_t [NrLanes-1:0]           alu_result_ff;
+  logic  [NrLanes-1:0][7:0]      be_id;
+  logic  [NrLanes*DataWidth-1:0] alu_operand, alu_operand_seq, alu_operand_seq_masked, alu_result_mask, alu_result_viota, alu_result_viota_masked, alu_result_viota_seq;
+
+  assign alu_operand = (vinsn_issue.op inside{[VIOTA:VID]}) ? viota_operand_i : alu_operand_i;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin: p_result_queue_ff
     if (!rst_ni) begin
@@ -251,7 +255,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
       result_queue_write_pnt_q <= result_queue_write_pnt_d;
       result_queue_read_pnt_q  <= result_queue_read_pnt_d;
       result_queue_cnt_q       <= result_queue_cnt_d;
-      alu_result_f             <= (vinsn_issue.op inside {[VMSBF:VMSIF]})  ? $unsigned(alu_result_mask) & bit_enable_mask : alu_result;
+      alu_result_f             <= (vinsn_issue.op inside {[VMSBF:VMSIF]})  ? alu_result_mask & bit_enable_mask : alu_result_viota_seq;
       alu_result_ff            <= alu_result_f;
     end
   end
@@ -327,135 +331,272 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
   generate
     case (NrLanes)
       2 : always_comb begin case (vinsn_issue.vtype.vsew)
-          EW8 : alu_operand_seq = {alu_operand_i[127:120], alu_operand_i[63:56], alu_operand_i[111:104], alu_operand_i[47:40], alu_operand_i[95:88 ], alu_operand_i[31:24] ,alu_operand_i[79:72], alu_operand_i[15:8],
-                                   alu_operand_i[119:112], alu_operand_i[55:48], alu_operand_i[87:80  ], alu_operand_i[23:16], alu_operand_i[103:96], alu_operand_i[39:32], alu_operand_i[71:64], alu_operand_i[7 :0]};
-          EW16: alu_operand_seq = {alu_operand_i[127:112], alu_operand_i[63:48], alu_operand_i[95:80 ], alu_operand_i[31:16],
-                                   alu_operand_i[111:96 ], alu_operand_i[47:32], alu_operand_i[79:64 ], alu_operand_i[15:0 ]};
-          EW32: alu_operand_seq = {alu_operand_i[127:96], alu_operand_i[63:32],
-                                   alu_operand_i[95:64 ], alu_operand_i[31:0 ]};
-          EW64: alu_operand_seq = {alu_operand_i[127:64 ],
-                                   alu_operand_i[63:0   ]};
+          EW8 : alu_operand_seq = {alu_operand[127:120], alu_operand[63:56], alu_operand[111:104], alu_operand[47:40], alu_operand[95 :88], alu_operand[31:24] ,alu_operand[79:72], alu_operand[15:8],
+                                   alu_operand[119:112], alu_operand[55:48], alu_operand[87 : 80], alu_operand[23:16], alu_operand[103:96], alu_operand[39:32], alu_operand[71:64], alu_operand[7 :0]};
+          EW16: alu_operand_seq = {alu_operand[127:112], alu_operand[63:48], alu_operand[95 : 80], alu_operand[31:16],
+                                   alu_operand[111: 96], alu_operand[47:32], alu_operand[79 : 64], alu_operand[15: 0]};
+          EW32: alu_operand_seq = {alu_operand[127: 96], alu_operand[63:32],
+                                   alu_operand[95 : 64], alu_operand[31: 0]};
+          EW64: alu_operand_seq = {alu_operand[127: 64],
+                                   alu_operand[63 :  0]};
         endcase
       end
       4 : always_comb begin case (vinsn_issue.vtype.vsew)
-          EW8 : alu_operand_seq = {alu_operand_i[255:248], alu_operand_i[191:184], alu_operand_i[127:120], alu_operand_i[63:56], alu_operand_i[223:216], alu_operand_i[159:152], alu_operand_i[95:88], alu_operand_i[31:24],
-                                   alu_operand_i[239:232], alu_operand_i[175:168], alu_operand_i[111:104], alu_operand_i[47:40], alu_operand_i[207:200], alu_operand_i[143:136], alu_operand_i[79:72], alu_operand_i[15:8 ],
-                                   alu_operand_i[247:240], alu_operand_i[183:176], alu_operand_i[119:112], alu_operand_i[55:48], alu_operand_i[215:208], alu_operand_i[151:144] ,alu_operand_i[87:80], alu_operand_i[23:16],
-                                   alu_operand_i[231:224], alu_operand_i[167:160], alu_operand_i[103:96 ], alu_operand_i[39:32], alu_operand_i[199:192], alu_operand_i[135:128], alu_operand_i[71:64], alu_operand_i[7 : 0]};
-          EW16: alu_operand_seq = {alu_operand_i[255:240], alu_operand_i[191:176], alu_operand_i[127:112], alu_operand_i[63:48],
-                                   alu_operand_i[223:208], alu_operand_i[159:144], alu_operand_i[95:80  ], alu_operand_i[31:16],
-                                   alu_operand_i[239:224], alu_operand_i[175:160], alu_operand_i[111:96 ], alu_operand_i[47:32],
-                                   alu_operand_i[207:192], alu_operand_i[143:128], alu_operand_i[79:64  ], alu_operand_i[15:0 ]};
-          EW32: alu_operand_seq = {alu_operand_i[255:224], alu_operand_i[191:160],
-                                   alu_operand_i[127:96 ], alu_operand_i[63:32  ],
-                                   alu_operand_i[223:192], alu_operand_i[159:128],
-                                   alu_operand_i[95:64  ], alu_operand_i[31:0   ]};
-          EW64: alu_operand_seq = {alu_operand_i[255:192],
-                                   alu_operand_i[191:128],
-                                   alu_operand_i[127:64 ],
-                                   alu_operand_i[63:0   ]};
+          EW8 : alu_operand_seq = {alu_operand[255:248], alu_operand[191:184], alu_operand[127:120], alu_operand[63:56], alu_operand[223:216], alu_operand[159:152], alu_operand[95:88], alu_operand[31:24],
+                                   alu_operand[239:232], alu_operand[175:168], alu_operand[111:104], alu_operand[47:40], alu_operand[207:200], alu_operand[143:136], alu_operand[79:72], alu_operand[15: 8],
+                                   alu_operand[247:240], alu_operand[183:176], alu_operand[119:112], alu_operand[55:48], alu_operand[215:208], alu_operand[151:144] ,alu_operand[87:80], alu_operand[23:16],
+                                   alu_operand[231:224], alu_operand[167:160], alu_operand[103: 96], alu_operand[39:32], alu_operand[199:192], alu_operand[135:128], alu_operand[71:64], alu_operand[7 : 0]};
+          EW16: alu_operand_seq = {alu_operand[255:240], alu_operand[191:176], alu_operand[127:112], alu_operand[63:48],
+                                   alu_operand[223:208], alu_operand[159:144], alu_operand[95 : 80], alu_operand[31:16],
+                                   alu_operand[239:224], alu_operand[175:160], alu_operand[111: 96], alu_operand[47:32],
+                                   alu_operand[207:192], alu_operand[143:128], alu_operand[79 : 64], alu_operand[15: 0]};
+          EW32: alu_operand_seq = {alu_operand[255:224], alu_operand[191:160],
+                                   alu_operand[127: 96], alu_operand[63 : 32],
+                                   alu_operand[223:192], alu_operand[159:128],
+                                   alu_operand[95 : 64], alu_operand[31 :  0]};
+          EW64: alu_operand_seq = {alu_operand[255:192],
+                                   alu_operand[191:128],
+                                   alu_operand[127: 64],
+                                   alu_operand[63 :  0]};
         endcase
       end
       8 : always_comb begin case (vinsn_issue.vtype.vsew)
-          EW8 : alu_operand_seq = {alu_operand_i[511:504], alu_operand_i[447:440], alu_operand_i[383:376], alu_operand_i[319:312], alu_operand_i[255:248], alu_operand_i[191:184], alu_operand_i[127:120], alu_operand_i[63:56],
-                                   alu_operand_i[479:472], alu_operand_i[415:408], alu_operand_i[351:344], alu_operand_i[287:280], alu_operand_i[223:216], alu_operand_i[159:152], alu_operand_i[95:88  ], alu_operand_i[31:24],
-                                   alu_operand_i[495:488], alu_operand_i[431:424], alu_operand_i[367:360], alu_operand_i[303:296], alu_operand_i[239:232], alu_operand_i[175:168], alu_operand_i[111:104], alu_operand_i[47:40],
-                                   alu_operand_i[463:456], alu_operand_i[399:392], alu_operand_i[335:328], alu_operand_i[271:264], alu_operand_i[207:200], alu_operand_i[143:136], alu_operand_i[79:72  ], alu_operand_i[15:8 ],
-                                   alu_operand_i[503:496], alu_operand_i[439:432], alu_operand_i[375:368], alu_operand_i[311:304], alu_operand_i[247:240], alu_operand_i[183:176], alu_operand_i[119:112], alu_operand_i[55:48],
-                                   alu_operand_i[471:464], alu_operand_i[407:400], alu_operand_i[343:336], alu_operand_i[279:272], alu_operand_i[215:208], alu_operand_i[151:144], alu_operand_i[87:80  ], alu_operand_i[23:16],
-                                   alu_operand_i[487:480], alu_operand_i[423:416], alu_operand_i[359:352], alu_operand_i[295:288], alu_operand_i[231:224], alu_operand_i[167:160], alu_operand_i[103:96 ], alu_operand_i[39:32],
-                                   alu_operand_i[455:448], alu_operand_i[391:384], alu_operand_i[327:320], alu_operand_i[263:256], alu_operand_i[199:192], alu_operand_i[135:128], alu_operand_i[71:64  ], alu_operand_i[7:0  ]};
-          EW16: alu_operand_seq = {alu_operand_i[511:496], alu_operand_i[447:432], alu_operand_i[383:368], alu_operand_i[319:304],
-                                   alu_operand_i[255:240], alu_operand_i[191:176], alu_operand_i[127:112], alu_operand_i[63 : 48],
-                                   alu_operand_i[479:464], alu_operand_i[415:400], alu_operand_i[351:336], alu_operand_i[287:272],
-                                   alu_operand_i[223:208], alu_operand_i[159:144], alu_operand_i[95 : 80], alu_operand_i[31 : 16],
-                                   alu_operand_i[495:480], alu_operand_i[431:416], alu_operand_i[367:352], alu_operand_i[303:288],
-                                   alu_operand_i[239:224], alu_operand_i[175:160], alu_operand_i[111 :96], alu_operand_i[47 : 32],
-                                   alu_operand_i[463:448], alu_operand_i[399:384], alu_operand_i[335:320], alu_operand_i[271:256],
-                                   alu_operand_i[207:192], alu_operand_i[143:128], alu_operand_i[79 : 64], alu_operand_i[15 : 0 ]};
-          EW32: alu_operand_seq = {alu_operand_i[511:480], alu_operand_i[447:416],
-                                   alu_operand_i[383:352], alu_operand_i[319:288],
-                                   alu_operand_i[255:224], alu_operand_i[191:160],
-                                   alu_operand_i[127: 96], alu_operand_i[63 : 32],
-                                   alu_operand_i[479:448], alu_operand_i[415:384],
-                                   alu_operand_i[351:320], alu_operand_i[287:256],
-                                   alu_operand_i[223:192], alu_operand_i[159:128],
-                                   alu_operand_i[95 : 64], alu_operand_i[31 : 0 ]};
-          EW64: alu_operand_seq = {alu_operand_i[511:448],
-                                   alu_operand_i[447:384],
-                                   alu_operand_i[383:320],
-                                   alu_operand_i[319:256],
-                                   alu_operand_i[255:192],
-                                   alu_operand_i[191:128],
-                                   alu_operand_i[127:64 ],
-                                   alu_operand_i[63:0   ]};
+          EW8 : alu_operand_seq = {alu_operand[511:504], alu_operand[447:440], alu_operand[383:376], alu_operand[319:312], alu_operand[255:248], alu_operand[191:184], alu_operand[127:120], alu_operand[63:56],
+                                   alu_operand[479:472], alu_operand[415:408], alu_operand[351:344], alu_operand[287:280], alu_operand[223:216], alu_operand[159:152], alu_operand[95 : 88], alu_operand[31:24],
+                                   alu_operand[495:488], alu_operand[431:424], alu_operand[367:360], alu_operand[303:296], alu_operand[239:232], alu_operand[175:168], alu_operand[111:104], alu_operand[47:40],
+                                   alu_operand[463:456], alu_operand[399:392], alu_operand[335:328], alu_operand[271:264], alu_operand[207:200], alu_operand[143:136], alu_operand[79 : 72], alu_operand[15: 8],
+                                   alu_operand[503:496], alu_operand[439:432], alu_operand[375:368], alu_operand[311:304], alu_operand[247:240], alu_operand[183:176], alu_operand[119:112], alu_operand[55:48],
+                                   alu_operand[471:464], alu_operand[407:400], alu_operand[343:336], alu_operand[279:272], alu_operand[215:208], alu_operand[151:144], alu_operand[87 : 80], alu_operand[23:16],
+                                   alu_operand[487:480], alu_operand[423:416], alu_operand[359:352], alu_operand[295:288], alu_operand[231:224], alu_operand[167:160], alu_operand[103: 96], alu_operand[39:32],
+                                   alu_operand[455:448], alu_operand[391:384], alu_operand[327:320], alu_operand[263:256], alu_operand[199:192], alu_operand[135:128], alu_operand[71 : 64], alu_operand[7 : 0]};
+          EW16: alu_operand_seq = {alu_operand[511:496], alu_operand[447:432], alu_operand[383:368], alu_operand[319:304],
+                                   alu_operand[255:240], alu_operand[191:176], alu_operand[127:112], alu_operand[63 : 48],
+                                   alu_operand[479:464], alu_operand[415:400], alu_operand[351:336], alu_operand[287:272],
+                                   alu_operand[223:208], alu_operand[159:144], alu_operand[95 : 80], alu_operand[31 : 16],
+                                   alu_operand[495:480], alu_operand[431:416], alu_operand[367:352], alu_operand[303:288],
+                                   alu_operand[239:224], alu_operand[175:160], alu_operand[111: 96], alu_operand[47 : 32],
+                                   alu_operand[463:448], alu_operand[399:384], alu_operand[335:320], alu_operand[271:256],
+                                   alu_operand[207:192], alu_operand[143:128], alu_operand[79 : 64], alu_operand[15 :  0]};
+          EW32: alu_operand_seq = {alu_operand[511:480], alu_operand[447:416],
+                                   alu_operand[383:352], alu_operand[319:288],
+                                   alu_operand[255:224], alu_operand[191:160],
+                                   alu_operand[127: 96], alu_operand[63 : 32],
+                                   alu_operand[479:448], alu_operand[415:384],
+                                   alu_operand[351:320], alu_operand[287:256],
+                                   alu_operand[223:192], alu_operand[159:128],
+                                   alu_operand[95 : 64], alu_operand[31 :  0]};
+          EW64: alu_operand_seq = {alu_operand[511:448],
+                                   alu_operand[447:384],
+                                   alu_operand[383:320],
+                                   alu_operand[319:256],
+                                   alu_operand[255:192],
+                                   alu_operand[191:128],
+                                   alu_operand[127: 64],
+                                   alu_operand[63 :  0]};
         endcase
       end
       16 : always_comb begin case (vinsn_issue.vtype.vsew)
-          EW8 : alu_operand_seq = {alu_operand_i[1023:1016], alu_operand_i[959:952], alu_operand_i[895:888], alu_operand_i[831:824], alu_operand_i[767:760], alu_operand_i[703:696], alu_operand_i[639:632], alu_operand_i[575:568],
-                                   alu_operand_i[511:504], alu_operand_i[447:440], alu_operand_i[383:376], alu_operand_i[319:312], alu_operand_i[255:248], alu_operand_i[191:184], alu_operand_i[127:120], alu_operand_i[63:56],
-                                   alu_operand_i[991:984], alu_operand_i[927:920], alu_operand_i[863:856], alu_operand_i[799:792], alu_operand_i[735:728], alu_operand_i[671:664], alu_operand_i[607:600], alu_operand_i[543:536],
-                                   alu_operand_i[479:472], alu_operand_i[415:408], alu_operand_i[351:344], alu_operand_i[287:280], alu_operand_i[223:216], alu_operand_i[159:152], alu_operand_i[95:88], alu_operand_i[31:24],
-                                   alu_operand_i[1007:1000], alu_operand_i[943:936], alu_operand_i[879:872], alu_operand_i[815:808], alu_operand_i[751:744], alu_operand_i[687:680], alu_operand_i[623:616], alu_operand_i[559:552],
-                                   alu_operand_i[495:488], alu_operand_i[431:424], alu_operand_i[367:360], alu_operand_i[303:296], alu_operand_i[239:232], alu_operand_i[175:168], alu_operand_i[111:104], alu_operand_i[47:40],
-                                   alu_operand_i[975:968], alu_operand_i[911:904], alu_operand_i[847:840], alu_operand_i[783:776], alu_operand_i[719:712], alu_operand_i[655:648], alu_operand_i[591:584], alu_operand_i[527:520],
-                                   alu_operand_i[463:456], alu_operand_i[399:392], alu_operand_i[335:328], alu_operand_i[271:264], alu_operand_i[207:200], alu_operand_i[143:136], alu_operand_i[79:72], alu_operand_i[15:8],
-                                   alu_operand_i[1015:1008], alu_operand_i[951:944], alu_operand_i[887:880], alu_operand_i[823:816], alu_operand_i[759:752], alu_operand_i[695:688], alu_operand_i[631:624], alu_operand_i[567:560],
-                                   alu_operand_i[503:496], alu_operand_i[439:432], alu_operand_i[375:368], alu_operand_i[311:304], alu_operand_i[247:240], alu_operand_i[183:176], alu_operand_i[119:112], alu_operand_i[55:48],
-                                   alu_operand_i[983:976], alu_operand_i[919:912], alu_operand_i[855:848], alu_operand_i[791:784], alu_operand_i[727:720], alu_operand_i[663:656], alu_operand_i[599:592], alu_operand_i[535:528],
-                                   alu_operand_i[471:464], alu_operand_i[407:400], alu_operand_i[343:336], alu_operand_i[279:272], alu_operand_i[215:208], alu_operand_i[151:144], alu_operand_i[87:80], alu_operand_i[23:16],
-                                   alu_operand_i[999:992], alu_operand_i[935:928], alu_operand_i[871:864], alu_operand_i[807:800], alu_operand_i[743:736], alu_operand_i[679:672], alu_operand_i[615:608], alu_operand_i[551:544],
-                                   alu_operand_i[487:480], alu_operand_i[423:416], alu_operand_i[359:352], alu_operand_i[295:288], alu_operand_i[231:224], alu_operand_i[167:160], alu_operand_i[103:96], alu_operand_i[39:32],
-                                   alu_operand_i[967:960], alu_operand_i[903:896], alu_operand_i[839:832], alu_operand_i[775:768], alu_operand_i[711:704], alu_operand_i[647:640], alu_operand_i[583:576], alu_operand_i[519:512],
-                                   alu_operand_i[455:448], alu_operand_i[391:384], alu_operand_i[327:320], alu_operand_i[263:256], alu_operand_i[199:192], alu_operand_i[135:128], alu_operand_i[71:64], alu_operand_i[7:0]};
-          EW16: alu_operand_seq = {alu_operand_i[1023:1008], alu_operand_i[959:944], alu_operand_i[895:880], alu_operand_i[831:816],
-                                   alu_operand_i[767:752], alu_operand_i[703:688], alu_operand_i[639:624], alu_operand_i[575:560],
-                                   alu_operand_i[511:496], alu_operand_i[447:432], alu_operand_i[383:368], alu_operand_i[319:304],
-                                   alu_operand_i[255:240], alu_operand_i[191:176], alu_operand_i[127:112], alu_operand_i[63:48],
-                                   alu_operand_i[991:976], alu_operand_i[927:912], alu_operand_i[863:848], alu_operand_i[799:784],
-                                   alu_operand_i[735:720], alu_operand_i[671:656], alu_operand_i[607:592], alu_operand_i[543:528],
-                                   alu_operand_i[479:464], alu_operand_i[415:400], alu_operand_i[351:336], alu_operand_i[287:272],
-                                   alu_operand_i[223:208], alu_operand_i[159:144], alu_operand_i[95:80], alu_operand_i[31:16],
-                                   alu_operand_i[1007:992], alu_operand_i[943:928], alu_operand_i[879:864], alu_operand_i[815:800],
-                                   alu_operand_i[751:736], alu_operand_i[687:672], alu_operand_i[623:608], alu_operand_i[559:544],
-                                   alu_operand_i[495:480], alu_operand_i[431:416], alu_operand_i[367:352], alu_operand_i[303:288],
-                                   alu_operand_i[239:224], alu_operand_i[175:160], alu_operand_i[111:96], alu_operand_i[47:32],
-                                   alu_operand_i[975:960], alu_operand_i[911:896], alu_operand_i[847:832], alu_operand_i[783:768],
-                                   alu_operand_i[719:704], alu_operand_i[655:640], alu_operand_i[591:576], alu_operand_i[527:512],
-                                   alu_operand_i[463:448], alu_operand_i[399:384], alu_operand_i[335:320], alu_operand_i[271:256],
-                                   alu_operand_i[207:192], alu_operand_i[143:128], alu_operand_i[79:64], alu_operand_i[15:0]};
-          EW32: alu_operand_seq = {alu_operand_i[1023:992], alu_operand_i[959:928],
-                                   alu_operand_i[895:864], alu_operand_i[831:800],
-                                   alu_operand_i[767:736], alu_operand_i[703:672],
-                                   alu_operand_i[639:608], alu_operand_i[575:544],
-                                   alu_operand_i[511:480], alu_operand_i[447:416],
-                                   alu_operand_i[383:352], alu_operand_i[319:288],
-                                   alu_operand_i[255:224], alu_operand_i[191:160],
-                                   alu_operand_i[127:96], alu_operand_i[63:32],
-                                   alu_operand_i[991:960], alu_operand_i[927:896],
-                                   alu_operand_i[863:832], alu_operand_i[799:768],
-                                   alu_operand_i[735:704], alu_operand_i[671:640],
-                                   alu_operand_i[607:576], alu_operand_i[543:512],
-                                   alu_operand_i[479:448], alu_operand_i[415:384],
-                                   alu_operand_i[351:320], alu_operand_i[287:256],
-                                   alu_operand_i[223:192], alu_operand_i[159:128],
-                                   alu_operand_i[95:64], alu_operand_i[31:0]};
-          EW64: alu_operand_seq = {alu_operand_i[1023:960],
-                                   alu_operand_i[959:896 ],
-                                   alu_operand_i[895:832 ],
-                                   alu_operand_i[831:768 ],
-                                   alu_operand_i[767:704 ],
-                                   alu_operand_i[703:640 ],
-                                   alu_operand_i[639:576 ],
-                                   alu_operand_i[575:512 ],
-                                   alu_operand_i[511:448 ],
-                                   alu_operand_i[447:384 ],
-                                   alu_operand_i[383:320 ],
-                                   alu_operand_i[319:256 ],
-                                   alu_operand_i[255:192 ],
-                                   alu_operand_i[191:128 ],
-                                   alu_operand_i[127:64  ],
-                                   alu_operand_i[63:0    ]};
+          EW8 : alu_operand_seq = {alu_operand[1023:1016], alu_operand[959:952], alu_operand[895:888], alu_operand[831:824], alu_operand[767:760], alu_operand[703:696], alu_operand[639:632], alu_operand[575:568],
+                                   alu_operand[511 : 504], alu_operand[447:440], alu_operand[383:376], alu_operand[319:312], alu_operand[255:248], alu_operand[191:184], alu_operand[127:120], alu_operand[63 : 56],
+                                   alu_operand[991 : 984], alu_operand[927:920], alu_operand[863:856], alu_operand[799:792], alu_operand[735:728], alu_operand[671:664], alu_operand[607:600], alu_operand[543:536],
+                                   alu_operand[479 : 472], alu_operand[415:408], alu_operand[351:344], alu_operand[287:280], alu_operand[223:216], alu_operand[159:152], alu_operand[95 : 88], alu_operand[31 : 24],
+                                   alu_operand[1007:1000], alu_operand[943:936], alu_operand[879:872], alu_operand[815:808], alu_operand[751:744], alu_operand[687:680], alu_operand[623:616], alu_operand[559:552],
+                                   alu_operand[495 : 488], alu_operand[431:424], alu_operand[367:360], alu_operand[303:296], alu_operand[239:232], alu_operand[175:168], alu_operand[111:104], alu_operand[47 : 40],
+                                   alu_operand[975 : 968], alu_operand[911:904], alu_operand[847:840], alu_operand[783:776], alu_operand[719:712], alu_operand[655:648], alu_operand[591:584], alu_operand[527:520],
+                                   alu_operand[463 : 456], alu_operand[399:392], alu_operand[335:328], alu_operand[271:264], alu_operand[207:200], alu_operand[143:136], alu_operand[79 : 72], alu_operand[15 :  8],
+                                   alu_operand[1015:1008], alu_operand[951:944], alu_operand[887:880], alu_operand[823:816], alu_operand[759:752], alu_operand[695:688], alu_operand[631:624], alu_operand[567:560],
+                                   alu_operand[503 : 496], alu_operand[439:432], alu_operand[375:368], alu_operand[311:304], alu_operand[247:240], alu_operand[183:176], alu_operand[119:112], alu_operand[55 : 48],
+                                   alu_operand[983 : 976], alu_operand[919:912], alu_operand[855:848], alu_operand[791:784], alu_operand[727:720], alu_operand[663:656], alu_operand[599:592], alu_operand[535:528],
+                                   alu_operand[471 : 464], alu_operand[407:400], alu_operand[343:336], alu_operand[279:272], alu_operand[215:208], alu_operand[151:144], alu_operand[87 : 80], alu_operand[23 : 16],
+                                   alu_operand[999 : 992], alu_operand[935:928], alu_operand[871:864], alu_operand[807:800], alu_operand[743:736], alu_operand[679:672], alu_operand[615:608], alu_operand[551:544],
+                                   alu_operand[487 : 480], alu_operand[423:416], alu_operand[359:352], alu_operand[295:288], alu_operand[231:224], alu_operand[167:160], alu_operand[103: 96], alu_operand[39 : 32],
+                                   alu_operand[967 : 960], alu_operand[903:896], alu_operand[839:832], alu_operand[775:768], alu_operand[711:704], alu_operand[647:640], alu_operand[583:576], alu_operand[519:512],
+                                   alu_operand[455 : 448], alu_operand[391:384], alu_operand[327:320], alu_operand[263:256], alu_operand[199:192], alu_operand[135:128], alu_operand[71 : 64], alu_operand[7  :  0]};
+          EW16: alu_operand_seq = {alu_operand[1023:1008], alu_operand[959:944], alu_operand[895:880], alu_operand[831:816],
+                                   alu_operand[767 : 752], alu_operand[703:688], alu_operand[639:624], alu_operand[575:560],
+                                   alu_operand[511 : 496], alu_operand[447:432], alu_operand[383:368], alu_operand[319:304],
+                                   alu_operand[255 : 240], alu_operand[191:176], alu_operand[127:112], alu_operand[63 : 48],
+                                   alu_operand[991 : 976], alu_operand[927:912], alu_operand[863:848], alu_operand[799:784],
+                                   alu_operand[735 : 720], alu_operand[671:656], alu_operand[607:592], alu_operand[543:528],
+                                   alu_operand[479 : 464], alu_operand[415:400], alu_operand[351:336], alu_operand[287:272],
+                                   alu_operand[223 : 208], alu_operand[159:144], alu_operand[95 : 80], alu_operand[31 : 16],
+                                   alu_operand[1007: 992], alu_operand[943:928], alu_operand[879:864], alu_operand[815:800],
+                                   alu_operand[751 : 736], alu_operand[687:672], alu_operand[623:608], alu_operand[559:544],
+                                   alu_operand[495 : 480], alu_operand[431:416], alu_operand[367:352], alu_operand[303:288],
+                                   alu_operand[239 : 224], alu_operand[175:160], alu_operand[111: 96], alu_operand[47 : 32],
+                                   alu_operand[975 : 960], alu_operand[911:896], alu_operand[847:832], alu_operand[783:768],
+                                   alu_operand[719 : 704], alu_operand[655:640], alu_operand[591:576], alu_operand[527:512],
+                                   alu_operand[463 : 448], alu_operand[399:384], alu_operand[335:320], alu_operand[271:256],
+                                   alu_operand[207 : 192], alu_operand[143:128], alu_operand[79 : 64], alu_operand[15 :  0]};
+          EW32: alu_operand_seq = {alu_operand[1023: 992], alu_operand[959:928],
+                                   alu_operand[895 : 864], alu_operand[831:800],
+                                   alu_operand[767 : 736], alu_operand[703:672],
+                                   alu_operand[639 : 608], alu_operand[575:544],
+                                   alu_operand[511 : 480], alu_operand[447:416],
+                                   alu_operand[383 : 352], alu_operand[319:288],
+                                   alu_operand[255 : 224], alu_operand[191:160],
+                                   alu_operand[127 :  96], alu_operand[63 : 32],
+                                   alu_operand[991 : 960], alu_operand[927:896],
+                                   alu_operand[863 : 832], alu_operand[799:768],
+                                   alu_operand[735 : 704], alu_operand[671:640],
+                                   alu_operand[607 : 576], alu_operand[543:512],
+                                   alu_operand[479 : 448], alu_operand[415:384],
+                                   alu_operand[351 : 320], alu_operand[287:256],
+                                   alu_operand[223 : 192], alu_operand[159:128],
+                                   alu_operand[95  :  64], alu_operand[31 :  0]};
+          EW64: alu_operand_seq = {alu_operand[1023: 960],
+                                   alu_operand[959 : 896],
+                                   alu_operand[895 : 832],
+                                   alu_operand[831 : 768],
+                                   alu_operand[767 : 704],
+                                   alu_operand[703 : 640],
+                                   alu_operand[639 : 576],
+                                   alu_operand[575 : 512],
+                                   alu_operand[511 : 448],
+                                   alu_operand[447 : 384],
+                                   alu_operand[383 : 320],
+                                   alu_operand[319 : 256],
+                                   alu_operand[255 : 192],
+                                   alu_operand[191 : 128],
+                                   alu_operand[127 :  64],
+                                   alu_operand[63  :   0]};
+        endcase
+      end
+    endcase
+  endgenerate
+
+  generate
+    case (NrLanes)
+      2 : always_comb begin case (vinsn_issue.vtype.vsew)
+          EW8 : alu_result_viota_seq = {alu_result_viota_masked[127:120], alu_result_viota_masked[63:56], alu_result_viota_masked[95:88], alu_result_viota_masked[31:24], alu_result_viota_masked[111:104], alu_result_viota_masked[47:40] ,alu_result_viota_masked[79:72], alu_result_viota_masked[15:8],
+                                        alu_result_viota_masked[119:112], alu_result_viota_masked[55:48], alu_result_viota_masked[87:80], alu_result_viota_masked[23:16], alu_result_viota_masked[103: 96], alu_result_viota_masked[39:32], alu_result_viota_masked[71:64], alu_result_viota_masked[7 :0]};
+          EW16: alu_result_viota_seq = {alu_result_viota_masked[127:112], alu_result_viota_masked[63:48], alu_result_viota_masked[95:80], alu_result_viota_masked[31:16],
+                                        alu_result_viota_masked[111: 96], alu_result_viota_masked[47:32], alu_result_viota_masked[79:64], alu_result_viota_masked[15: 0]};
+          EW32: alu_result_viota_seq = {alu_result_viota_masked[127: 96], alu_result_viota_masked[63:32],
+                                        alu_result_viota_masked[95 : 64], alu_result_viota_masked[31: 0]};
+          EW64: alu_result_viota_seq = {alu_result_viota_masked[127: 64],
+                                        alu_result_viota_masked[63 :  0]};
+        endcase
+      end
+      4 : always_comb begin case (vinsn_issue.vtype.vsew)
+          EW8 : alu_result_viota_seq = {alu_result_viota_masked[255:248], alu_result_viota_masked[191:184], alu_result_viota_masked[127:120], alu_result_viota_masked[63:56], alu_result_viota_masked[223:216], alu_result_viota_masked[159:152], alu_result_viota_masked[95:88], alu_result_viota_masked[31:24],
+                                        alu_result_viota_masked[247:240], alu_result_viota_masked[183:176], alu_result_viota_masked[119:112], alu_result_viota_masked[55:48], alu_result_viota_masked[215:208], alu_result_viota_masked[151:144] ,alu_result_viota_masked[87:80], alu_result_viota_masked[23:16],
+                                        alu_result_viota_masked[239:232], alu_result_viota_masked[175:168], alu_result_viota_masked[111:104], alu_result_viota_masked[47:40], alu_result_viota_masked[207:200], alu_result_viota_masked[143:136], alu_result_viota_masked[79:72], alu_result_viota_masked[15: 8],
+                                        alu_result_viota_masked[231:224], alu_result_viota_masked[167:160], alu_result_viota_masked[103: 96], alu_result_viota_masked[39:32], alu_result_viota_masked[199:192], alu_result_viota_masked[135:128], alu_result_viota_masked[71:64], alu_result_viota_masked[7 : 0]};
+          EW16: alu_result_viota_seq = {alu_result_viota_masked[255:240], alu_result_viota_masked[191:176], alu_result_viota_masked[127:112], alu_result_viota_masked[63:48],
+                                        alu_result_viota_masked[223:208], alu_result_viota_masked[159:144], alu_result_viota_masked[95 : 80], alu_result_viota_masked[31:16],
+                                        alu_result_viota_masked[239:224], alu_result_viota_masked[175:160], alu_result_viota_masked[111: 96], alu_result_viota_masked[47:32],
+                                        alu_result_viota_masked[207:192], alu_result_viota_masked[143:128], alu_result_viota_masked[79 : 64], alu_result_viota_masked[15: 0]};
+          EW32: alu_result_viota_seq = {alu_result_viota_masked[255:224], alu_result_viota_masked[191:160],
+                                        alu_result_viota_masked[127: 96], alu_result_viota_masked[63 : 32],
+                                        alu_result_viota_masked[223:192], alu_result_viota_masked[159:128],
+                                        alu_result_viota_masked[95 : 64], alu_result_viota_masked[31 :  0]};
+          EW64: alu_result_viota_seq = {alu_result_viota_masked[255:192],
+                                        alu_result_viota_masked[191:128],
+                                        alu_result_viota_masked[127: 64],
+                                        alu_result_viota_masked[63 :  0]};
+        endcase
+      end
+      8 : always_comb begin case (vinsn_issue.vtype.vsew)
+          EW8 : alu_result_viota_seq = {alu_result_viota_masked[511:504], alu_result_viota_masked[447:440], alu_result_viota_masked[383:376], alu_result_viota_masked[319:312], alu_result_viota_masked[255:248], alu_result_viota_masked[191:184], alu_result_viota_masked[127:120], alu_result_viota_masked[63:56],
+                                        alu_result_viota_masked[503:496], alu_result_viota_masked[439:432], alu_result_viota_masked[375:368], alu_result_viota_masked[311:304], alu_result_viota_masked[247:240], alu_result_viota_masked[183:176], alu_result_viota_masked[119:112], alu_result_viota_masked[55:48],
+                                        alu_result_viota_masked[495:488], alu_result_viota_masked[431:424], alu_result_viota_masked[367:360], alu_result_viota_masked[303:296], alu_result_viota_masked[239:232], alu_result_viota_masked[175:168], alu_result_viota_masked[111:104], alu_result_viota_masked[47:40],
+                                        alu_result_viota_masked[487:480], alu_result_viota_masked[423:416], alu_result_viota_masked[359:352], alu_result_viota_masked[295:288], alu_result_viota_masked[231:224], alu_result_viota_masked[167:160], alu_result_viota_masked[103: 96], alu_result_viota_masked[39:32],
+                                        alu_result_viota_masked[479:472], alu_result_viota_masked[415:408], alu_result_viota_masked[351:344], alu_result_viota_masked[287:280], alu_result_viota_masked[223:216], alu_result_viota_masked[159:152], alu_result_viota_masked[95 : 88], alu_result_viota_masked[31:24],
+                                        alu_result_viota_masked[471:464], alu_result_viota_masked[407:400], alu_result_viota_masked[343:336], alu_result_viota_masked[279:272], alu_result_viota_masked[215:208], alu_result_viota_masked[151:144], alu_result_viota_masked[87 : 80], alu_result_viota_masked[23:16],
+                                        alu_result_viota_masked[463:456], alu_result_viota_masked[399:392], alu_result_viota_masked[335:328], alu_result_viota_masked[271:264], alu_result_viota_masked[207:200], alu_result_viota_masked[143:136], alu_result_viota_masked[79 : 72], alu_result_viota_masked[15: 8],
+                                        alu_result_viota_masked[455:448], alu_result_viota_masked[391:384], alu_result_viota_masked[327:320], alu_result_viota_masked[263:256], alu_result_viota_masked[199:192], alu_result_viota_masked[135:128], alu_result_viota_masked[71 : 64], alu_result_viota_masked[7 : 0]};
+          EW16: alu_result_viota_seq = {alu_result_viota_masked[511:496], alu_result_viota_masked[447:432], alu_result_viota_masked[383:368], alu_result_viota_masked[319:304],
+                                        alu_result_viota_masked[255:240], alu_result_viota_masked[191:176], alu_result_viota_masked[127:112], alu_result_viota_masked[63 : 48],
+                                        alu_result_viota_masked[479:464], alu_result_viota_masked[415:400], alu_result_viota_masked[351:336], alu_result_viota_masked[287:272],
+                                        alu_result_viota_masked[223:208], alu_result_viota_masked[159:144], alu_result_viota_masked[95 : 80], alu_result_viota_masked[31 : 16],
+                                        alu_result_viota_masked[495:480], alu_result_viota_masked[431:416], alu_result_viota_masked[367:352], alu_result_viota_masked[303:288],
+                                        alu_result_viota_masked[239:224], alu_result_viota_masked[175:160], alu_result_viota_masked[111: 96], alu_result_viota_masked[47 : 32],
+                                        alu_result_viota_masked[463:448], alu_result_viota_masked[399:384], alu_result_viota_masked[335:320], alu_result_viota_masked[271:256],
+                                        alu_result_viota_masked[207:192], alu_result_viota_masked[143:128], alu_result_viota_masked[79 : 64], alu_result_viota_masked[15 :  0]};
+          EW32: alu_result_viota_seq = {alu_result_viota_masked[511:480], alu_result_viota_masked[447:416],
+                                        alu_result_viota_masked[383:352], alu_result_viota_masked[319:288],
+                                        alu_result_viota_masked[255:224], alu_result_viota_masked[191:160],
+                                        alu_result_viota_masked[127: 96], alu_result_viota_masked[63 : 32],
+                                        alu_result_viota_masked[479:448], alu_result_viota_masked[415:384],
+                                        alu_result_viota_masked[351:320], alu_result_viota_masked[287:256],
+                                        alu_result_viota_masked[223:192], alu_result_viota_masked[159:128],
+                                        alu_result_viota_masked[95 : 64], alu_result_viota_masked[31 :  0]};
+          EW64: alu_result_viota_seq = {alu_result_viota_masked[511:448],
+                                        alu_result_viota_masked[447:384],
+                                        alu_result_viota_masked[383:320],
+                                        alu_result_viota_masked[319:256],
+                                        alu_result_viota_masked[255:192],
+                                        alu_result_viota_masked[191:128],
+                                        alu_result_viota_masked[127: 64],
+                                        alu_result_viota_masked[63 :  0]};
+        endcase
+      end
+      16 : always_comb begin case (vinsn_issue.vtype.vsew)
+          EW8 : alu_result_viota_seq = {alu_result_viota_masked[1023:1016], alu_result_viota_masked[959:952], alu_result_viota_masked[895:888], alu_result_viota_masked[831:824], alu_result_viota_masked[767:760], alu_result_viota_masked[703:696], alu_result_viota_masked[639:632], alu_result_viota_masked[575:568],
+                                        alu_result_viota_masked[1015:1008], alu_result_viota_masked[951:944], alu_result_viota_masked[887:880], alu_result_viota_masked[823:816], alu_result_viota_masked[759:752], alu_result_viota_masked[695:688], alu_result_viota_masked[631:624], alu_result_viota_masked[567:560],
+                                        alu_result_viota_masked[1007:1000], alu_result_viota_masked[943:936], alu_result_viota_masked[879:872], alu_result_viota_masked[815:808], alu_result_viota_masked[751:744], alu_result_viota_masked[687:680], alu_result_viota_masked[623:616], alu_result_viota_masked[559:552],
+                                        alu_result_viota_masked[999 : 992], alu_result_viota_masked[935:928], alu_result_viota_masked[871:864], alu_result_viota_masked[807:800], alu_result_viota_masked[743:736], alu_result_viota_masked[679:672], alu_result_viota_masked[615:608], alu_result_viota_masked[551:544],
+                                        alu_result_viota_masked[991 : 984], alu_result_viota_masked[927:920], alu_result_viota_masked[863:856], alu_result_viota_masked[799:792], alu_result_viota_masked[735:728], alu_result_viota_masked[671:664], alu_result_viota_masked[607:600], alu_result_viota_masked[543:536],
+                                        alu_result_viota_masked[983 : 976], alu_result_viota_masked[919:912], alu_result_viota_masked[855:848], alu_result_viota_masked[791:784], alu_result_viota_masked[727:720], alu_result_viota_masked[663:656], alu_result_viota_masked[599:592], alu_result_viota_masked[535:528],
+                                        alu_result_viota_masked[975 : 968], alu_result_viota_masked[911:904], alu_result_viota_masked[847:840], alu_result_viota_masked[783:776], alu_result_viota_masked[719:712], alu_result_viota_masked[655:648], alu_result_viota_masked[591:584], alu_result_viota_masked[527:520],
+                                        alu_result_viota_masked[967 : 960], alu_result_viota_masked[903:896], alu_result_viota_masked[839:832], alu_result_viota_masked[775:768], alu_result_viota_masked[711:704], alu_result_viota_masked[647:640], alu_result_viota_masked[583:576], alu_result_viota_masked[519:512],
+                                        alu_result_viota_masked[511 : 504], alu_result_viota_masked[447:440], alu_result_viota_masked[383:376], alu_result_viota_masked[319:312], alu_result_viota_masked[255:248], alu_result_viota_masked[191:184], alu_result_viota_masked[127:120], alu_result_viota_masked[63 : 56],
+                                        alu_result_viota_masked[503 : 496], alu_result_viota_masked[439:432], alu_result_viota_masked[375:368], alu_result_viota_masked[311:304], alu_result_viota_masked[247:240], alu_result_viota_masked[183:176], alu_result_viota_masked[119:112], alu_result_viota_masked[55 : 48],
+                                        alu_result_viota_masked[495 : 488], alu_result_viota_masked[431:424], alu_result_viota_masked[367:360], alu_result_viota_masked[303:296], alu_result_viota_masked[239:232], alu_result_viota_masked[175:168], alu_result_viota_masked[111:104], alu_result_viota_masked[47 : 40],
+                                        alu_result_viota_masked[487 : 480], alu_result_viota_masked[423:416], alu_result_viota_masked[359:352], alu_result_viota_masked[295:288], alu_result_viota_masked[231:224], alu_result_viota_masked[167:160], alu_result_viota_masked[103: 96], alu_result_viota_masked[39 : 32],
+                                        alu_result_viota_masked[479 : 472], alu_result_viota_masked[415:408], alu_result_viota_masked[351:344], alu_result_viota_masked[287:280], alu_result_viota_masked[223:216], alu_result_viota_masked[159:152], alu_result_viota_masked[95 : 88], alu_result_viota_masked[31 : 24],
+                                        alu_result_viota_masked[471 : 464], alu_result_viota_masked[407:400], alu_result_viota_masked[343:336], alu_result_viota_masked[279:272], alu_result_viota_masked[215:208], alu_result_viota_masked[151:144], alu_result_viota_masked[87 : 80], alu_result_viota_masked[23 : 16],
+                                        alu_result_viota_masked[463 : 456], alu_result_viota_masked[399:392], alu_result_viota_masked[335:328], alu_result_viota_masked[271:264], alu_result_viota_masked[207:200], alu_result_viota_masked[143:136], alu_result_viota_masked[79 : 72], alu_result_viota_masked[15 :  8],
+                                        alu_result_viota_masked[455 : 448], alu_result_viota_masked[391:384], alu_result_viota_masked[327:320], alu_result_viota_masked[263:256], alu_result_viota_masked[199:192], alu_result_viota_masked[135:128], alu_result_viota_masked[71 : 64], alu_result_viota_masked[7  :  0]};
+          EW16: alu_result_viota_seq = {alu_result_viota_masked[1023:1008], alu_result_viota_masked[959:944], alu_result_viota_masked[895:880], alu_result_viota_masked[831:816],
+                                        alu_result_viota_masked[767 : 752], alu_result_viota_masked[703:688], alu_result_viota_masked[639:624], alu_result_viota_masked[575:560],
+                                        alu_result_viota_masked[511 : 496], alu_result_viota_masked[447:432], alu_result_viota_masked[383:368], alu_result_viota_masked[319:304],
+                                        alu_result_viota_masked[255 : 240], alu_result_viota_masked[191:176], alu_result_viota_masked[127:112], alu_result_viota_masked[63 : 48],
+                                        alu_result_viota_masked[991 : 976], alu_result_viota_masked[927:912], alu_result_viota_masked[863:848], alu_result_viota_masked[799:784],
+                                        alu_result_viota_masked[735 : 720], alu_result_viota_masked[671:656], alu_result_viota_masked[607:592], alu_result_viota_masked[543:528],
+                                        alu_result_viota_masked[479 : 464], alu_result_viota_masked[415:400], alu_result_viota_masked[351:336], alu_result_viota_masked[287:272],
+                                        alu_result_viota_masked[223 : 208], alu_result_viota_masked[159:144], alu_result_viota_masked[95 : 80], alu_result_viota_masked[31 : 16],
+                                        alu_result_viota_masked[1007: 992], alu_result_viota_masked[943:928], alu_result_viota_masked[879:864], alu_result_viota_masked[815:800],
+                                        alu_result_viota_masked[751 : 736], alu_result_viota_masked[687:672], alu_result_viota_masked[623:608], alu_result_viota_masked[559:544],
+                                        alu_result_viota_masked[495 : 480], alu_result_viota_masked[431:416], alu_result_viota_masked[367:352], alu_result_viota_masked[303:288],
+                                        alu_result_viota_masked[239 : 224], alu_result_viota_masked[175:160], alu_result_viota_masked[111: 96], alu_result_viota_masked[47 : 32],
+                                        alu_result_viota_masked[975 : 960], alu_result_viota_masked[911:896], alu_result_viota_masked[847:832], alu_result_viota_masked[783:768],
+                                        alu_result_viota_masked[719 : 704], alu_result_viota_masked[655:640], alu_result_viota_masked[591:576], alu_result_viota_masked[527:512],
+                                        alu_result_viota_masked[463 : 448], alu_result_viota_masked[399:384], alu_result_viota_masked[335:320], alu_result_viota_masked[271:256],
+                                        alu_result_viota_masked[207 : 192], alu_result_viota_masked[143:128], alu_result_viota_masked[79 : 64], alu_result_viota_masked[15 :  0]};
+          EW32: alu_result_viota_seq = {alu_result_viota_masked[1023: 992], alu_result_viota_masked[959:928],
+                                        alu_result_viota_masked[895 : 864], alu_result_viota_masked[831:800],
+                                        alu_result_viota_masked[767 : 736], alu_result_viota_masked[703:672],
+                                        alu_result_viota_masked[639 : 608], alu_result_viota_masked[575:544],
+                                        alu_result_viota_masked[511 : 480], alu_result_viota_masked[447:416],
+                                        alu_result_viota_masked[383 : 352], alu_result_viota_masked[319:288],
+                                        alu_result_viota_masked[255 : 224], alu_result_viota_masked[191:160],
+                                        alu_result_viota_masked[127 :  96], alu_result_viota_masked[63 : 32],
+                                        alu_result_viota_masked[991 : 960], alu_result_viota_masked[927:896],
+                                        alu_result_viota_masked[863 : 832], alu_result_viota_masked[799:768],
+                                        alu_result_viota_masked[735 : 704], alu_result_viota_masked[671:640],
+                                        alu_result_viota_masked[607 : 576], alu_result_viota_masked[543:512],
+                                        alu_result_viota_masked[479 : 448], alu_result_viota_masked[415:384],
+                                        alu_result_viota_masked[351 : 320], alu_result_viota_masked[287:256],
+                                        alu_result_viota_masked[223 : 192], alu_result_viota_masked[159:128],
+                                        alu_result_viota_masked[95  :  64], alu_result_viota_masked[31 :  0]};
+          EW64: alu_result_viota_seq = {alu_result_viota_masked[1023: 960],
+                                        alu_result_viota_masked[959 : 896],
+                                        alu_result_viota_masked[895 : 832],
+                                        alu_result_viota_masked[831 : 768],
+                                        alu_result_viota_masked[767 : 704],
+                                        alu_result_viota_masked[703 : 640],
+                                        alu_result_viota_masked[639 : 576],
+                                        alu_result_viota_masked[575 : 512],
+                                        alu_result_viota_masked[511 : 448],
+                                        alu_result_viota_masked[447 : 384],
+                                        alu_result_viota_masked[383 : 320],
+                                        alu_result_viota_masked[319 : 256],
+                                        alu_result_viota_masked[255 : 192],
+                                        alu_result_viota_masked[191 : 128],
+                                        alu_result_viota_masked[127 :  64],
+                                        alu_result_viota_masked[63  :   0]};
         endcase
       end
     endcase
@@ -467,6 +608,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
     bit_enable_shuffle = '0;
     bit_enable_mask    = '0;
     alu_result_mask    = '0;
+    alu_result_viota   = '0;
 
     vcpop_to_count     = '0;
 
@@ -516,71 +658,72 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
               end
           end
         end
-        VIOTA :begin
-          unique case (vinsn_issue.vtype.vsew)
-            EW8: begin
-                sum_0 = '0;
-                sum_1 = '0;
-                sum_2 = '0;
-                sum_3 = '0;
-                sum_4 = '0;
-                sum_5 = '0;
-                sum_6 = '0;
-                for (int i=0; i<32; i++) begin
-                  sum_0 = sum_0 + alu_operand_seq[i];
-                end
-                for (int i=0; i<64; i++) begin
-                  sum_1 = sum_1 + alu_operand_seq[i];
-                end
-                for (int i=0; i<96; i++) begin
-                  sum_2 = sum_2 + alu_operand_seq[i];
-                end
-                for (int i=0; i<128; i++) begin
-                  sum_3 = sum_3 + alu_operand_seq[i];
-                end
-                for (int i=0; i<160; i++) begin
-                  sum_4 = sum_4 + alu_operand_seq[i];
-                end
-                for (int i=0; i<192; i++) begin
-                  sum_5 = sum_5 + alu_operand_seq[i];
-                end
-                for (int i=0; i<224; i++) begin
-                  sum_6 = sum_6 + alu_operand_seq[i];
-                end
-                alu_result [0] = {{24{1'b0}},sum_3,{24{1'b0}},{8{1'b0}}} & {{24{1'b0}},{8{bit_enable_mask[3]}},{24{1'b0}},{8{bit_enable_mask[7]}}};
-                be_id [0] = 8'b00010001;
-                alu_result [1] = {{24{1'b0}},sum_4,{24{1'b0}},sum_0} & {{24{1'b0}},{8{bit_enable_mask[2]}},{24{1'b0}},{8{bit_enable_mask[6]}}};
-                be_id [1] = 8'b00010001;
-                alu_result [2] = {{24{1'b0}},sum_5,{24{1'b0}},sum_1} & {{24{1'b0}},{8{bit_enable_mask[1]}},{24{1'b0}},{8{bit_enable_mask[5]}}};
-                be_id [2] = 8'b00010001;
-                alu_result [3] = {{24{1'b0}},sum_6,{24{1'b0}},sum_2} & {{24{1'b0}},{8{bit_enable_mask[0]}},{24{1'b0}},{8{bit_enable_mask[4]}}};
-                be_id [3] = 8'b00010001;
-              end
-            EW16: for (int b = 0; b < 16; b++) begin
-                /* TO DO */
-              end
-            EW32: for (int b = 0; b < 8; b++) begin
-                /* TO DO */
-              end
-            EW64: for (int b = 0; b < 4; b++) begin
-                /* TO DO */
-              end
-          endcase
-        end
-        VID : begin
-          alu_result [0] = 64'd17179869184 & {{24{1'b0}},{8{bit_enable_mask[4]}},{24{1'b0}},{8{bit_enable_mask[0]}}};
-          be_id [0] = 8'b00010001;
-          alu_result [1] = 64'd21474836481 & {{24{1'b0}},{8{bit_enable_mask[5]}},{24{1'b0}},{8{bit_enable_mask[1]}}};
-          be_id [1] = 8'b00010001;
-          alu_result [2] = 64'd25769803778 & {{24{1'b0}},{8{bit_enable_mask[6]}},{24{1'b0}},{8{bit_enable_mask[2]}}};
-          be_id [2] = 8'b00010001;
-          alu_result [3] = 64'd30064771075 & {{24{1'b0}},{8{bit_enable_mask[7]}},{24{1'b0}},{8{bit_enable_mask[3]}}};
-          be_id [3] = 8'b00010001;
-        end
         [VMANDN:VMSIF]: alu_result = (masku_operand_a_i & bit_enable_mask) |
           (masku_operand_b_i & ~bit_enable_mask);
         VMXNOR: alu_result = (masku_operand_a_i & bit_enable_mask) |
           (masku_operand_b_i & ~bit_enable_mask);
+        VIOTA: begin
+          be_id = 64'd18446744073709551615;
+          unique case (vinsn_issue.vtype.vsew)
+            EW8 : begin
+              alu_operand_seq_masked = alu_operand_seq & {{8{|bit_enable_mask[7]}},{8{|bit_enable_mask[6]}},{8{|bit_enable_mask[5]}},{8{|bit_enable_mask[4]}},{8{|bit_enable_mask[3]}},{8{|bit_enable_mask[2]}},{8{|bit_enable_mask[1]}},{8{|bit_enable_mask[0]}}};
+              for (int index = 1; index < (NrLanes*DataWidth)/8; index++) begin
+                alu_result_viota [(index*8) +: 7] = alu_operand_seq_masked [((index-1)*8) +: 7] + alu_result_viota [((index-1)*8) +: 7];
+                alu_result_viota_masked = alu_result_viota & {{8{|bit_enable_mask[7]}},{8{|bit_enable_mask[6]}},{8{|bit_enable_mask[5]}},{8{|bit_enable_mask[4]}},{8{|bit_enable_mask[3]}},{8{|bit_enable_mask[2]}},{8{|bit_enable_mask[1]}},{8{|bit_enable_mask[0]}}};
+              end
+            end
+            EW16: begin
+              alu_operand_seq_masked = alu_operand_seq & {{16{|bit_enable_mask[7]}},{16{|bit_enable_mask[6]}},{16{|bit_enable_mask[5]}},{16{|bit_enable_mask[4]}},{16{|bit_enable_mask[3]}},{16{|bit_enable_mask[2]}},{16{|bit_enable_mask[1]}},{16{|bit_enable_mask[0]}}};
+              for (int index = 1; index < (NrLanes*DataWidth)/16; index++) begin
+                alu_result_viota [(index*16) +: 15] = alu_operand_seq_masked [((index-1)*16) +: 15] + alu_result_viota [((index-1)*16) +: 15];
+                alu_result_viota_masked = alu_result_viota & {{16{|bit_enable_mask[7]}},{16{|bit_enable_mask[6]}},{16{|bit_enable_mask[5]}},{16{|bit_enable_mask[4]}},{16{|bit_enable_mask[3]}},{16{|bit_enable_mask[2]}},{16{|bit_enable_mask[1]}},{16{|bit_enable_mask[0]}}};
+              end
+            end
+            EW32: begin
+              alu_operand_seq_masked = alu_operand_seq & {{32{|bit_enable_mask[7]}},{32{|bit_enable_mask[6]}},{32{|bit_enable_mask[5]}},{32{|bit_enable_mask[4]}},{32{|bit_enable_mask[3]}},{32{|bit_enable_mask[2]}},{32{|bit_enable_mask[1]}},{32{|bit_enable_mask[0]}}};
+              for (int index = 1; index < (NrLanes*DataWidth)/32; index++) begin
+                alu_result_viota [(index*32) +: 31] = alu_operand_seq_masked [((index-1)*32) +: 31] + alu_result_viota [((index-1)*32) +: 31];
+                alu_result_viota_masked = alu_result_viota & {{32{|bit_enable_mask[7]}},{32{|bit_enable_mask[6]}},{32{|bit_enable_mask[5]}},{32{|bit_enable_mask[4]}},{32{|bit_enable_mask[3]}},{32{|bit_enable_mask[2]}},{32{|bit_enable_mask[1]}},{32{|bit_enable_mask[0]}}};
+              end
+            end
+            EW64: begin
+              alu_operand_seq_masked = alu_operand_seq & {{64{|bit_enable_mask[7]}},{64{|bit_enable_mask[6]}},{64{|bit_enable_mask[5]}},{64{|bit_enable_mask[4]}},{64{|bit_enable_mask[3]}},{64{|bit_enable_mask[2]}},{64{|bit_enable_mask[1]}},{64{|bit_enable_mask[0]}}};
+              for (int index = 1; index < (NrLanes*DataWidth)/64; index++) begin
+                alu_result_viota [(index*64) +: 63] = alu_operand_seq_masked [((index-1)*64) +: 63] + alu_result_viota [((index-1)*64) +: 63];
+                alu_result_viota_masked = alu_result_viota & {{64{|bit_enable_mask[7]}},{64{|bit_enable_mask[6]}},{64{|bit_enable_mask[5]}},{64{|bit_enable_mask[4]}},{64{|bit_enable_mask[3]}},{64{|bit_enable_mask[2]}},{64{|bit_enable_mask[1]}},{64{|bit_enable_mask[0]}}};
+              end
+            end
+          endcase
+        end
+        VID: begin
+          be_id = 64'd18446744073709551615;
+          unique case (vinsn_issue.vtype.vsew)
+            EW8 : begin
+              for (int index = 1; index < (NrLanes*DataWidth)/8; index++) begin
+                alu_result_viota [(index*8) +: 7] = index;
+                alu_result_viota_masked = alu_result_viota & {{8{|bit_enable_mask[7]}},{8{|bit_enable_mask[6]}},{8{|bit_enable_mask[5]}},{8{|bit_enable_mask[4]}},{8{|bit_enable_mask[3]}},{8{|bit_enable_mask[2]}},{8{|bit_enable_mask[1]}},{8{|bit_enable_mask[0]}}};
+              end
+            end
+            EW16: begin
+              for (int index = 1; index < (NrLanes*DataWidth)/16; index++) begin
+                alu_result_viota [(index*16) +: 15] = index;
+                alu_result_viota_masked = alu_result_viota & {{16{|bit_enable_mask[7]}},{16{|bit_enable_mask[6]}},{16{|bit_enable_mask[5]}},{16{|bit_enable_mask[4]}},{16{|bit_enable_mask[3]}},{16{|bit_enable_mask[2]}},{16{|bit_enable_mask[1]}},{16{|bit_enable_mask[0]}}};
+              end
+            end
+            EW32: begin
+              for (int index = 1; index < (NrLanes*DataWidth)/32; index++) begin
+                alu_result_viota [(index*32) +: 31] = index;
+                alu_result_viota_masked = alu_result_viota & {{32{|bit_enable_mask[7]}},{32{|bit_enable_mask[6]}},{32{|bit_enable_mask[5]}},{32{|bit_enable_mask[4]}},{32{|bit_enable_mask[3]}},{32{|bit_enable_mask[2]}},{32{|bit_enable_mask[1]}},{32{|bit_enable_mask[0]}}};
+              end
+            end
+            EW64: begin
+              for (int index = 1; index < (NrLanes*DataWidth)/64; index++) begin
+                alu_result_viota [(index*64) +: 63] = index;
+                alu_result_viota_masked = alu_result_viota & {{64{|bit_enable_mask[7]}},{64{|bit_enable_mask[6]}},{64{|bit_enable_mask[5]}},{64{|bit_enable_mask[4]}},{64{|bit_enable_mask[3]}},{64{|bit_enable_mask[2]}},{64{|bit_enable_mask[1]}},{64{|bit_enable_mask[0]}}};
+              end
+            end
+          endcase
+        end
         [VMFEQ:VMSBC] : begin
           automatic logic [ELEN*NrLanes-1:0] alu_result_flat = '0;
 
@@ -869,8 +1012,8 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
               element_cnt += 1;
 
             result_queue_d[result_queue_write_pnt_q][lane] = '{
-              wdata: (vinsn_issue.op inside {[VMSBF:VIOTA]}) ? result_queue_q[result_queue_write_pnt_q][lane].wdata | alu_result_ff[lane] : result_queue_q[result_queue_write_pnt_q][lane].wdata | alu_result[lane],
-              be   : (vinsn_issue.op == VID || vinsn_issue.op == VIOTA) ? be_id[lane] : be(element_cnt, vinsn_issue.vtype.vsew),
+              wdata: (vinsn_issue.op inside {[VMSBF:VMSIF]}) ? result_queue_q[result_queue_write_pnt_q][lane].wdata | alu_result_ff[lane] : (vinsn_issue.op inside {[VIOTA:VID]}) ? result_queue_q[result_queue_write_pnt_q][lane].wdata | alu_result_f[lane] : result_queue_q[result_queue_write_pnt_q][lane].wdata | alu_result[lane],
+              be   : (vinsn_issue.op inside {[VIOTA:  VID]}) ? be_id[lane] : be(element_cnt, vinsn_issue.vtype.vsew),
               addr : vaddr(vinsn_issue.vd, NrLanes) +
                 (((vinsn_issue.vl - issue_cnt_q) / NrLanes / DataWidth)),
               id : vinsn_issue.id

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -99,7 +99,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
     end: gen_masku_operand_ready
 
     assign masku_operand_b_i[lane]        = masku_operand_i[lane][1];
-    assign masku_operand_b_valid_i[lane]  = (vinsn_issue.op == VID) ? '1 : masku_operand_valid_i[lane][1];
+    assign masku_operand_b_valid_i[lane]  = (vinsn_issue.op inside {[VMSBF:VID]}) ? '1 : masku_operand_valid_i[lane][1];
     assign masku_operand_ready_o[lane][1] = masku_operand_b_ready_o[lane];
 
     assign masku_operand_m_i[lane]        = masku_operand_i[lane][0];

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -251,7 +251,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
       result_queue_write_pnt_q <= result_queue_write_pnt_d;
       result_queue_read_pnt_q  <= result_queue_read_pnt_d;
       result_queue_cnt_q       <= result_queue_cnt_d;
-      alu_result_f             <= (vinsn_issue.op inside {[VMSBF:VMSIF]})  ? alu_result_mask & bit_enable_mask : alu_result;
+      alu_result_f             <= (vinsn_issue.op inside {[VMSBF:VMSIF]})  ? $unsigned(alu_result_mask) & bit_enable_mask : alu_result;
       alu_result_ff            <= alu_result_f;
     end
   end
@@ -466,6 +466,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
     bit_enable         = '0;
     bit_enable_shuffle = '0;
     bit_enable_mask    = '0;
+    alu_result_mask    = '0;
 
     vcpop_to_count     = '0;
 

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -33,6 +33,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
     input  logic                                       clk_i,
     input  logic                                       rst_ni,
     input  logic [DataWidth*NrLanes-1:0]               alu_operand_i,
+    input  logic [NrLanes-1:0]                         alu_operand_valid_i,
     // Interface with the main sequencer
     input  pe_req_t                                    pe_req_i,
     input  logic                                       pe_req_valid_i,
@@ -64,14 +65,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
 
   import cf_math_pkg::idx_width;
 
-  typedef union packed {
-    logic [3:0 ][63:0] w64;
-    logic [7:0 ][31:0] w32;
-    logic [15:0][15:0] w16;
-    logic [31:0][ 7:0] w8;
-  } masku_operand_t;
-
-  masku_operand_t alu_operand_seq;
+  logic [NrLanes*DataWidth-1:0] alu_operand_seq;
 
   ////////////////
   //  Operands  //
@@ -257,7 +251,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
       result_queue_write_pnt_q <= result_queue_write_pnt_d;
       result_queue_read_pnt_q  <= result_queue_read_pnt_d;
       result_queue_cnt_q       <= result_queue_cnt_d;
-      alu_result_f             <= alu_result;
+      alu_result_f             <= (vinsn_issue.op inside {[VMSBF:VMSIF]})  ? alu_result_mask & bit_enable_mask : alu_result;
       alu_result_ff            <= alu_result_f;
     end
   end
@@ -294,8 +288,6 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
   logic  [7:0] sum_4;
   logic  [7:0] sum_5;
   logic  [7:0] sum_6;
-  logic  [2:0] id_count;
-  assign id_count = issue_cnt_d;
   logic  [NrLanes-1:0][7:0] be_id;
 
   elen_t        [NrLanes-1:0]                           alu_result;
@@ -312,6 +304,8 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
   // vfirst variables
   logic         [NrLanes*ELEN-1:0]                        vfirst_to_count;
   logic         [DataWidth-1:0]                           vfirst_count;
+  // vmsbf, vmsof and vmsif variables
+  logic         [NrLanes*DataWidth-1:0]                 alu_result_mask;
 
   // Pointers
   //
@@ -330,6 +324,142 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
     );
   end
 
+  generate
+    case (NrLanes)
+      2 : always_comb begin case (vinsn_issue.vtype.vsew)
+          EW8 : alu_operand_seq = {alu_operand_i[127:120], alu_operand_i[63:56], alu_operand_i[111:104], alu_operand_i[47:40], alu_operand_i[95:88 ], alu_operand_i[31:24] ,alu_operand_i[79:72], alu_operand_i[15:8],
+                                   alu_operand_i[119:112], alu_operand_i[55:48], alu_operand_i[87:80  ], alu_operand_i[23:16], alu_operand_i[103:96], alu_operand_i[39:32], alu_operand_i[71:64], alu_operand_i[7 :0]};
+          EW16: alu_operand_seq = {alu_operand_i[127:112], alu_operand_i[63:48], alu_operand_i[95:80 ], alu_operand_i[31:16],
+                                   alu_operand_i[111:96 ], alu_operand_i[47:32], alu_operand_i[79:64 ], alu_operand_i[15:0 ]};
+          EW32: alu_operand_seq = {alu_operand_i[127:96], alu_operand_i[63:32],
+                                   alu_operand_i[95:64 ], alu_operand_i[31:0 ]};
+          EW64: alu_operand_seq = {alu_operand_i[127:64 ],
+                                   alu_operand_i[63:0   ]};
+        endcase
+      end
+      4 : always_comb begin case (vinsn_issue.vtype.vsew)
+          EW8 : alu_operand_seq = {alu_operand_i[255:248], alu_operand_i[191:184], alu_operand_i[127:120], alu_operand_i[63:56], alu_operand_i[223:216], alu_operand_i[159:152], alu_operand_i[95:88], alu_operand_i[31:24],
+                                   alu_operand_i[239:232], alu_operand_i[175:168], alu_operand_i[111:104], alu_operand_i[47:40], alu_operand_i[207:200], alu_operand_i[143:136], alu_operand_i[79:72], alu_operand_i[15:8 ],
+                                   alu_operand_i[247:240], alu_operand_i[183:176], alu_operand_i[119:112], alu_operand_i[55:48], alu_operand_i[215:208], alu_operand_i[151:144] ,alu_operand_i[87:80], alu_operand_i[23:16],
+                                   alu_operand_i[231:224], alu_operand_i[167:160], alu_operand_i[103:96 ], alu_operand_i[39:32], alu_operand_i[199:192], alu_operand_i[135:128], alu_operand_i[71:64], alu_operand_i[7 : 0]};
+          EW16: alu_operand_seq = {alu_operand_i[255:240], alu_operand_i[191:176], alu_operand_i[127:112], alu_operand_i[63:48],
+                                   alu_operand_i[223:208], alu_operand_i[159:144], alu_operand_i[95:80  ], alu_operand_i[31:16],
+                                   alu_operand_i[239:224], alu_operand_i[175:160], alu_operand_i[111:96 ], alu_operand_i[47:32],
+                                   alu_operand_i[207:192], alu_operand_i[143:128], alu_operand_i[79:64  ], alu_operand_i[15:0 ]};
+          EW32: alu_operand_seq = {alu_operand_i[255:224], alu_operand_i[191:160],
+                                   alu_operand_i[127:96 ], alu_operand_i[63:32  ],
+                                   alu_operand_i[223:192], alu_operand_i[159:128],
+                                   alu_operand_i[95:64  ], alu_operand_i[31:0   ]};
+          EW64: alu_operand_seq = {alu_operand_i[255:192],
+                                   alu_operand_i[191:128],
+                                   alu_operand_i[127:64 ],
+                                   alu_operand_i[63:0   ]};
+        endcase
+      end
+      8 : always_comb begin case (vinsn_issue.vtype.vsew)
+          EW8 : alu_operand_seq = {alu_operand_i[511:504], alu_operand_i[447:440], alu_operand_i[383:376], alu_operand_i[319:312], alu_operand_i[255:248], alu_operand_i[191:184], alu_operand_i[127:120], alu_operand_i[63:56],
+                                   alu_operand_i[479:472], alu_operand_i[415:408], alu_operand_i[351:344], alu_operand_i[287:280], alu_operand_i[223:216], alu_operand_i[159:152], alu_operand_i[95:88  ], alu_operand_i[31:24],
+                                   alu_operand_i[495:488], alu_operand_i[431:424], alu_operand_i[367:360], alu_operand_i[303:296], alu_operand_i[239:232], alu_operand_i[175:168], alu_operand_i[111:104], alu_operand_i[47:40],
+                                   alu_operand_i[463:456], alu_operand_i[399:392], alu_operand_i[335:328], alu_operand_i[271:264], alu_operand_i[207:200], alu_operand_i[143:136], alu_operand_i[79:72  ], alu_operand_i[15:8 ],
+                                   alu_operand_i[503:496], alu_operand_i[439:432], alu_operand_i[375:368], alu_operand_i[311:304], alu_operand_i[247:240], alu_operand_i[183:176], alu_operand_i[119:112], alu_operand_i[55:48],
+                                   alu_operand_i[471:464], alu_operand_i[407:400], alu_operand_i[343:336], alu_operand_i[279:272], alu_operand_i[215:208], alu_operand_i[151:144], alu_operand_i[87:80  ], alu_operand_i[23:16],
+                                   alu_operand_i[487:480], alu_operand_i[423:416], alu_operand_i[359:352], alu_operand_i[295:288], alu_operand_i[231:224], alu_operand_i[167:160], alu_operand_i[103:96 ], alu_operand_i[39:32],
+                                   alu_operand_i[455:448], alu_operand_i[391:384], alu_operand_i[327:320], alu_operand_i[263:256], alu_operand_i[199:192], alu_operand_i[135:128], alu_operand_i[71:64  ], alu_operand_i[7:0  ]};
+          EW16: alu_operand_seq = {alu_operand_i[511:496], alu_operand_i[447:432], alu_operand_i[383:368], alu_operand_i[319:304],
+                                   alu_operand_i[255:240], alu_operand_i[191:176], alu_operand_i[127:112], alu_operand_i[63 : 48],
+                                   alu_operand_i[479:464], alu_operand_i[415:400], alu_operand_i[351:336], alu_operand_i[287:272],
+                                   alu_operand_i[223:208], alu_operand_i[159:144], alu_operand_i[95 : 80], alu_operand_i[31 : 16],
+                                   alu_operand_i[495:480], alu_operand_i[431:416], alu_operand_i[367:352], alu_operand_i[303:288],
+                                   alu_operand_i[239:224], alu_operand_i[175:160], alu_operand_i[111 :96], alu_operand_i[47 : 32],
+                                   alu_operand_i[463:448], alu_operand_i[399:384], alu_operand_i[335:320], alu_operand_i[271:256],
+                                   alu_operand_i[207:192], alu_operand_i[143:128], alu_operand_i[79 : 64], alu_operand_i[15 : 0 ]};
+          EW32: alu_operand_seq = {alu_operand_i[511:480], alu_operand_i[447:416],
+                                   alu_operand_i[383:352], alu_operand_i[319:288],
+                                   alu_operand_i[255:224], alu_operand_i[191:160],
+                                   alu_operand_i[127: 96], alu_operand_i[63 : 32],
+                                   alu_operand_i[479:448], alu_operand_i[415:384],
+                                   alu_operand_i[351:320], alu_operand_i[287:256],
+                                   alu_operand_i[223:192], alu_operand_i[159:128],
+                                   alu_operand_i[95 : 64], alu_operand_i[31 : 0 ]};
+          EW64: alu_operand_seq = {alu_operand_i[511:448],
+                                   alu_operand_i[447:384],
+                                   alu_operand_i[383:320],
+                                   alu_operand_i[319:256],
+                                   alu_operand_i[255:192],
+                                   alu_operand_i[191:128],
+                                   alu_operand_i[127:64 ],
+                                   alu_operand_i[63:0   ]};
+        endcase
+      end
+      16 : always_comb begin case (vinsn_issue.vtype.vsew)
+          EW8 : alu_operand_seq = {alu_operand_i[1023:1016], alu_operand_i[959:952], alu_operand_i[895:888], alu_operand_i[831:824], alu_operand_i[767:760], alu_operand_i[703:696], alu_operand_i[639:632], alu_operand_i[575:568],
+                                   alu_operand_i[511:504], alu_operand_i[447:440], alu_operand_i[383:376], alu_operand_i[319:312], alu_operand_i[255:248], alu_operand_i[191:184], alu_operand_i[127:120], alu_operand_i[63:56],
+                                   alu_operand_i[991:984], alu_operand_i[927:920], alu_operand_i[863:856], alu_operand_i[799:792], alu_operand_i[735:728], alu_operand_i[671:664], alu_operand_i[607:600], alu_operand_i[543:536],
+                                   alu_operand_i[479:472], alu_operand_i[415:408], alu_operand_i[351:344], alu_operand_i[287:280], alu_operand_i[223:216], alu_operand_i[159:152], alu_operand_i[95:88], alu_operand_i[31:24],
+                                   alu_operand_i[1007:1000], alu_operand_i[943:936], alu_operand_i[879:872], alu_operand_i[815:808], alu_operand_i[751:744], alu_operand_i[687:680], alu_operand_i[623:616], alu_operand_i[559:552],
+                                   alu_operand_i[495:488], alu_operand_i[431:424], alu_operand_i[367:360], alu_operand_i[303:296], alu_operand_i[239:232], alu_operand_i[175:168], alu_operand_i[111:104], alu_operand_i[47:40],
+                                   alu_operand_i[975:968], alu_operand_i[911:904], alu_operand_i[847:840], alu_operand_i[783:776], alu_operand_i[719:712], alu_operand_i[655:648], alu_operand_i[591:584], alu_operand_i[527:520],
+                                   alu_operand_i[463:456], alu_operand_i[399:392], alu_operand_i[335:328], alu_operand_i[271:264], alu_operand_i[207:200], alu_operand_i[143:136], alu_operand_i[79:72], alu_operand_i[15:8],
+                                   alu_operand_i[1015:1008], alu_operand_i[951:944], alu_operand_i[887:880], alu_operand_i[823:816], alu_operand_i[759:752], alu_operand_i[695:688], alu_operand_i[631:624], alu_operand_i[567:560],
+                                   alu_operand_i[503:496], alu_operand_i[439:432], alu_operand_i[375:368], alu_operand_i[311:304], alu_operand_i[247:240], alu_operand_i[183:176], alu_operand_i[119:112], alu_operand_i[55:48],
+                                   alu_operand_i[983:976], alu_operand_i[919:912], alu_operand_i[855:848], alu_operand_i[791:784], alu_operand_i[727:720], alu_operand_i[663:656], alu_operand_i[599:592], alu_operand_i[535:528],
+                                   alu_operand_i[471:464], alu_operand_i[407:400], alu_operand_i[343:336], alu_operand_i[279:272], alu_operand_i[215:208], alu_operand_i[151:144], alu_operand_i[87:80], alu_operand_i[23:16],
+                                   alu_operand_i[999:992], alu_operand_i[935:928], alu_operand_i[871:864], alu_operand_i[807:800], alu_operand_i[743:736], alu_operand_i[679:672], alu_operand_i[615:608], alu_operand_i[551:544],
+                                   alu_operand_i[487:480], alu_operand_i[423:416], alu_operand_i[359:352], alu_operand_i[295:288], alu_operand_i[231:224], alu_operand_i[167:160], alu_operand_i[103:96], alu_operand_i[39:32],
+                                   alu_operand_i[967:960], alu_operand_i[903:896], alu_operand_i[839:832], alu_operand_i[775:768], alu_operand_i[711:704], alu_operand_i[647:640], alu_operand_i[583:576], alu_operand_i[519:512],
+                                   alu_operand_i[455:448], alu_operand_i[391:384], alu_operand_i[327:320], alu_operand_i[263:256], alu_operand_i[199:192], alu_operand_i[135:128], alu_operand_i[71:64], alu_operand_i[7:0]};
+          EW16: alu_operand_seq = {alu_operand_i[1023:1008], alu_operand_i[959:944], alu_operand_i[895:880], alu_operand_i[831:816],
+                                   alu_operand_i[767:752], alu_operand_i[703:688], alu_operand_i[639:624], alu_operand_i[575:560],
+                                   alu_operand_i[511:496], alu_operand_i[447:432], alu_operand_i[383:368], alu_operand_i[319:304],
+                                   alu_operand_i[255:240], alu_operand_i[191:176], alu_operand_i[127:112], alu_operand_i[63:48],
+                                   alu_operand_i[991:976], alu_operand_i[927:912], alu_operand_i[863:848], alu_operand_i[799:784],
+                                   alu_operand_i[735:720], alu_operand_i[671:656], alu_operand_i[607:592], alu_operand_i[543:528],
+                                   alu_operand_i[479:464], alu_operand_i[415:400], alu_operand_i[351:336], alu_operand_i[287:272],
+                                   alu_operand_i[223:208], alu_operand_i[159:144], alu_operand_i[95:80], alu_operand_i[31:16],
+                                   alu_operand_i[1007:992], alu_operand_i[943:928], alu_operand_i[879:864], alu_operand_i[815:800],
+                                   alu_operand_i[751:736], alu_operand_i[687:672], alu_operand_i[623:608], alu_operand_i[559:544],
+                                   alu_operand_i[495:480], alu_operand_i[431:416], alu_operand_i[367:352], alu_operand_i[303:288],
+                                   alu_operand_i[239:224], alu_operand_i[175:160], alu_operand_i[111:96], alu_operand_i[47:32],
+                                   alu_operand_i[975:960], alu_operand_i[911:896], alu_operand_i[847:832], alu_operand_i[783:768],
+                                   alu_operand_i[719:704], alu_operand_i[655:640], alu_operand_i[591:576], alu_operand_i[527:512],
+                                   alu_operand_i[463:448], alu_operand_i[399:384], alu_operand_i[335:320], alu_operand_i[271:256],
+                                   alu_operand_i[207:192], alu_operand_i[143:128], alu_operand_i[79:64], alu_operand_i[15:0]};
+          EW32: alu_operand_seq = {alu_operand_i[1023:992], alu_operand_i[959:928],
+                                   alu_operand_i[895:864], alu_operand_i[831:800],
+                                   alu_operand_i[767:736], alu_operand_i[703:672],
+                                   alu_operand_i[639:608], alu_operand_i[575:544],
+                                   alu_operand_i[511:480], alu_operand_i[447:416],
+                                   alu_operand_i[383:352], alu_operand_i[319:288],
+                                   alu_operand_i[255:224], alu_operand_i[191:160],
+                                   alu_operand_i[127:96], alu_operand_i[63:32],
+                                   alu_operand_i[991:960], alu_operand_i[927:896],
+                                   alu_operand_i[863:832], alu_operand_i[799:768],
+                                   alu_operand_i[735:704], alu_operand_i[671:640],
+                                   alu_operand_i[607:576], alu_operand_i[543:512],
+                                   alu_operand_i[479:448], alu_operand_i[415:384],
+                                   alu_operand_i[351:320], alu_operand_i[287:256],
+                                   alu_operand_i[223:192], alu_operand_i[159:128],
+                                   alu_operand_i[95:64], alu_operand_i[31:0]};
+          EW64: alu_operand_seq = {alu_operand_i[1023:960],
+                                   alu_operand_i[959:896 ],
+                                   alu_operand_i[895:832 ],
+                                   alu_operand_i[831:768 ],
+                                   alu_operand_i[767:704 ],
+                                   alu_operand_i[703:640 ],
+                                   alu_operand_i[639:576 ],
+                                   alu_operand_i[575:512 ],
+                                   alu_operand_i[511:448 ],
+                                   alu_operand_i[447:384 ],
+                                   alu_operand_i[383:320 ],
+                                   alu_operand_i[319:256 ],
+                                   alu_operand_i[255:192 ],
+                                   alu_operand_i[191:128 ],
+                                   alu_operand_i[127:64  ],
+                                   alu_operand_i[63:0    ]};
+        endcase
+      end
+    endcase
+  endgenerate
 
   always_comb begin: p_mask_alu
     alu_result         = '0;
@@ -371,6 +501,20 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
 
       // Evaluate the instruction
       unique case (vinsn_issue.op) inside
+        [VMANDN:VMXNOR]: alu_result = (masku_operand_a_i & bit_enable_mask) |
+          (masku_operand_b_i & ~bit_enable_mask);
+        [VMSBF:VMSIF] : begin
+          if (alu_operand_valid_i) begin
+              for (int i = 0; i < NrLanes * DataWidth; i++) begin
+                  if (alu_operand_seq[i] == 1'b0) begin
+                      alu_result_mask[i] = (vinsn_issue.op == VMSOF) ? 1'b0 : 1'b1;
+                  end else begin
+                      alu_result_mask[i] = (vinsn_issue.op == VMSBF) ? 1'b0 : 1'b1;
+                      i = NrLanes * DataWidth;
+                  end
+              end
+          end
+        end
         VIOTA :begin
           unique case (vinsn_issue.vtype.vsew)
             EW8: begin
@@ -381,7 +525,6 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
                 sum_4 = '0;
                 sum_5 = '0;
                 sum_6 = '0;
-                alu_operand_seq = {{24{1'b0}},alu_operand_i[231:224],{24{1'b0}},alu_operand_i[167:160],{24{1'b0}},alu_operand_i[103:96],{24{1'b0}},alu_operand_i[39:32],{24{1'b0}},alu_operand_i[199:192],{24{1'b0}},alu_operand_i[135:128],{24{1'b0}},alu_operand_i[71:64],{24{1'b0}},alu_operand_i[7:0]} & {{24{1'b0}},{8{bit_enable_mask[0]}},{24{1'b0}},{8{bit_enable_mask[1]}},{24{1'b0}},{8{bit_enable_mask[2]}},{24{1'b0}},{8{bit_enable_mask[3]}},{24{1'b0}},{8{bit_enable_mask[4]}},{24{1'b0}},{8{bit_enable_mask[5]}},{24{1'b0}},{8{bit_enable_mask[6]}},{24{1'b0}},{8{bit_enable_mask[7]}}};
                 for (int i=0; i<32; i++) begin
                   sum_0 = sum_0 + alu_operand_seq[i];
                 end
@@ -725,7 +868,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
               element_cnt += 1;
 
             result_queue_d[result_queue_write_pnt_q][lane] = '{
-              wdata: (vinsn_issue.op == VIOTA) ? result_queue_q[result_queue_write_pnt_q][lane].wdata | alu_result_ff[lane] : result_queue_q[result_queue_write_pnt_q][lane].wdata | alu_result[lane],
+              wdata: (vinsn_issue.op inside {[VMSBF:VIOTA]}) ? result_queue_q[result_queue_write_pnt_q][lane].wdata | alu_result_ff[lane] : result_queue_q[result_queue_write_pnt_q][lane].wdata | alu_result[lane],
               be   : (vinsn_issue.op == VID || vinsn_issue.op == VIOTA) ? be_id[lane] : be(element_cnt, vinsn_issue.vtype.vsew),
               addr : vaddr(vinsn_issue.vd, NrLanes) +
                 (((vinsn_issue.vl - issue_cnt_q) / NrLanes / DataWidth)),

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -51,8 +51,10 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
     output strb_t    [NrLanes-1:0]                     masku_result_be_o,
     input  logic     [NrLanes-1:0]                     masku_result_gnt_i,
     input  logic     [NrLanes-1:0]                     masku_result_final_gnt_i,
-    input  logic     [DataWidth*NrLanes-1:0]           alu_operand_i,
-    input  logic     [NrLanes-1:0]                     alu_operand_valid_i,
+    input  logic     [DataWidth*NrLanes-1:0]           alu_operand_a_i,
+    input  logic     [NrLanes-1:0]                     alu_operand_a_valid_i,
+    input  logic     [DataWidth*NrLanes-1:0]           alu_operand_b_i,
+    input  logic     [NrLanes-1:0]                     alu_operand_b_valid_i,
     input  logic     [DataWidth*NrLanes-1:0]           viota_operand_i,
     input  logic     [NrLanes-1:0]                     viota_operand_valid_i,
     // Interface with the VFUs
@@ -97,7 +99,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
     end: gen_masku_operand_ready
 
     assign masku_operand_b_i[lane]        = masku_operand_i[lane][1];
-    assign masku_operand_b_valid_i[lane]  = masku_operand_valid_i[lane][1];
+    assign masku_operand_b_valid_i[lane]  = (vinsn_issue.op == VID) ? '1 : masku_operand_valid_i[lane][1];
     assign masku_operand_ready_o[lane][1] = masku_operand_b_ready_o[lane];
 
     assign masku_operand_m_i[lane]        = masku_operand_i[lane][0];
@@ -235,10 +237,12 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
   // vmsbf, vmsif, vmsof, viota, vid variables
   elen_t [NrLanes-1:0]           alu_result_f;
   elen_t [NrLanes-1:0]           alu_result_ff;
-  logic  [NrLanes-1:0][7:0]      be_id;
-  logic  [NrLanes*DataWidth-1:0] alu_operand, alu_operand_seq, alu_operand_seq_masked, alu_result_mask, alu_result_viota, alu_result_viota_masked, alu_result_viota_seq;
+  logic  [NrLanes*DataWidth-1:0] alu_operand_a_seq, alu_operand_a_seq_f;
+  logic  [NrLanes*DataWidth-1:0] alu_operand_b, alu_operand_b_seq, alu_operand_b_seq_m;
+  logic  [NrLanes*DataWidth-1:0] alu_result_vm, alu_result_vm_m, alu_result_vm_seq;
 
-  assign alu_operand = (vinsn_issue.op inside{[VIOTA:VID]}) ? viota_operand_i : alu_operand_i;
+  // operand_b selection
+  assign alu_operand_b = (vinsn_issue.op inside{[VIOTA:VID]}) ? viota_operand_i : alu_operand_b_i;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin: p_result_queue_ff
     if (!rst_ni) begin
@@ -255,7 +259,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
       result_queue_write_pnt_q <= result_queue_write_pnt_d;
       result_queue_read_pnt_q  <= result_queue_read_pnt_d;
       result_queue_cnt_q       <= result_queue_cnt_d;
-      alu_result_f             <= (vinsn_issue.op inside {[VMSBF:VMSIF]})  ? alu_result_mask & bit_enable_mask : alu_result_viota_seq;
+      alu_result_f             <= (vinsn_issue.op inside {[VMSBF:VMSIF]})  ? alu_result_vm & bit_enable_mask : alu_result_vm_seq;
       alu_result_ff            <= alu_result_f;
     end
   end
@@ -313,7 +317,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
   elen_t [NrLanes-1:0]      alu_result;
   logic  [NrLanes*ELEN-1:0] bit_enable;
   logic  [NrLanes*ELEN-1:0] bit_enable_shuffle;
-  logic  [NrLanes*ELEN-1:0] bit_enable_mask;
+  logic  [NrLanes*ELEN-1:0] bit_enable_mask, mask;
 
   // Pointers
   //
@@ -322,297 +326,39 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
   // We need a pointer to which bit on the full VRF word we are writing results to.
   logic [idx_width(DataWidth*NrLanes):0] vrf_pnt_d, vrf_pnt_q;
 
-  // Vector population counter for vcpop.m instruction
-  for (genvar lane = 0; lane < NrLanes; lane++) begin : gen_popcounters
-    popcount #(
-      .INPUT_WIDTH(DataWidth)
-    ) i_popcount (
-      .data_i    (vcpop_to_count[lane*ELEN +: ELEN]),
-      .popcount_o(popcount[lane])
-    );
-  end
+  // sequencing operand_a
+  op_seq #(
+    .NrLanes(NrLanes)
+  ) i_op_a_seq (
+    .vsew             (vinsn_issue.vtype.vsew),
+    .alu_operand      (alu_operand_a_i       ),
+    .alu_operand_seq  (alu_operand_a_seq     )
+  );
 
-  generate
-    case (NrLanes)
-      2 : always_comb begin case (vinsn_issue.vtype.vsew)
-          EW8 : alu_operand_seq = {alu_operand[127:120], alu_operand[63:56], alu_operand[111:104], alu_operand[47:40], alu_operand[95 :88], alu_operand[31:24] ,alu_operand[79:72], alu_operand[15:8],
-                                   alu_operand[119:112], alu_operand[55:48], alu_operand[87 : 80], alu_operand[23:16], alu_operand[103:96], alu_operand[39:32], alu_operand[71:64], alu_operand[7 :0]};
-          EW16: alu_operand_seq = {alu_operand[127:112], alu_operand[63:48], alu_operand[95 : 80], alu_operand[31:16],
-                                   alu_operand[111: 96], alu_operand[47:32], alu_operand[79 : 64], alu_operand[15: 0]};
-          EW32: alu_operand_seq = {alu_operand[127: 96], alu_operand[63:32],
-                                   alu_operand[95 : 64], alu_operand[31: 0]};
-          EW64: alu_operand_seq = {alu_operand[127: 64],
-                                   alu_operand[63 :  0]};
-        endcase
-      end
-      4 : always_comb begin case (vinsn_issue.vtype.vsew)
-          EW8 : alu_operand_seq = {alu_operand[255:248], alu_operand[191:184], alu_operand[127:120], alu_operand[63:56], alu_operand[223:216], alu_operand[159:152], alu_operand[95:88], alu_operand[31:24],
-                                   alu_operand[239:232], alu_operand[175:168], alu_operand[111:104], alu_operand[47:40], alu_operand[207:200], alu_operand[143:136], alu_operand[79:72], alu_operand[15: 8],
-                                   alu_operand[247:240], alu_operand[183:176], alu_operand[119:112], alu_operand[55:48], alu_operand[215:208], alu_operand[151:144] ,alu_operand[87:80], alu_operand[23:16],
-                                   alu_operand[231:224], alu_operand[167:160], alu_operand[103: 96], alu_operand[39:32], alu_operand[199:192], alu_operand[135:128], alu_operand[71:64], alu_operand[7 : 0]};
-          EW16: alu_operand_seq = {alu_operand[255:240], alu_operand[191:176], alu_operand[127:112], alu_operand[63:48],
-                                   alu_operand[223:208], alu_operand[159:144], alu_operand[95 : 80], alu_operand[31:16],
-                                   alu_operand[239:224], alu_operand[175:160], alu_operand[111: 96], alu_operand[47:32],
-                                   alu_operand[207:192], alu_operand[143:128], alu_operand[79 : 64], alu_operand[15: 0]};
-          EW32: alu_operand_seq = {alu_operand[255:224], alu_operand[191:160],
-                                   alu_operand[127: 96], alu_operand[63 : 32],
-                                   alu_operand[223:192], alu_operand[159:128],
-                                   alu_operand[95 : 64], alu_operand[31 :  0]};
-          EW64: alu_operand_seq = {alu_operand[255:192],
-                                   alu_operand[191:128],
-                                   alu_operand[127: 64],
-                                   alu_operand[63 :  0]};
-        endcase
-      end
-      8 : always_comb begin case (vinsn_issue.vtype.vsew)
-          EW8 : alu_operand_seq = {alu_operand[511:504], alu_operand[447:440], alu_operand[383:376], alu_operand[319:312], alu_operand[255:248], alu_operand[191:184], alu_operand[127:120], alu_operand[63:56],
-                                   alu_operand[479:472], alu_operand[415:408], alu_operand[351:344], alu_operand[287:280], alu_operand[223:216], alu_operand[159:152], alu_operand[95 : 88], alu_operand[31:24],
-                                   alu_operand[495:488], alu_operand[431:424], alu_operand[367:360], alu_operand[303:296], alu_operand[239:232], alu_operand[175:168], alu_operand[111:104], alu_operand[47:40],
-                                   alu_operand[463:456], alu_operand[399:392], alu_operand[335:328], alu_operand[271:264], alu_operand[207:200], alu_operand[143:136], alu_operand[79 : 72], alu_operand[15: 8],
-                                   alu_operand[503:496], alu_operand[439:432], alu_operand[375:368], alu_operand[311:304], alu_operand[247:240], alu_operand[183:176], alu_operand[119:112], alu_operand[55:48],
-                                   alu_operand[471:464], alu_operand[407:400], alu_operand[343:336], alu_operand[279:272], alu_operand[215:208], alu_operand[151:144], alu_operand[87 : 80], alu_operand[23:16],
-                                   alu_operand[487:480], alu_operand[423:416], alu_operand[359:352], alu_operand[295:288], alu_operand[231:224], alu_operand[167:160], alu_operand[103: 96], alu_operand[39:32],
-                                   alu_operand[455:448], alu_operand[391:384], alu_operand[327:320], alu_operand[263:256], alu_operand[199:192], alu_operand[135:128], alu_operand[71 : 64], alu_operand[7 : 0]};
-          EW16: alu_operand_seq = {alu_operand[511:496], alu_operand[447:432], alu_operand[383:368], alu_operand[319:304],
-                                   alu_operand[255:240], alu_operand[191:176], alu_operand[127:112], alu_operand[63 : 48],
-                                   alu_operand[479:464], alu_operand[415:400], alu_operand[351:336], alu_operand[287:272],
-                                   alu_operand[223:208], alu_operand[159:144], alu_operand[95 : 80], alu_operand[31 : 16],
-                                   alu_operand[495:480], alu_operand[431:416], alu_operand[367:352], alu_operand[303:288],
-                                   alu_operand[239:224], alu_operand[175:160], alu_operand[111: 96], alu_operand[47 : 32],
-                                   alu_operand[463:448], alu_operand[399:384], alu_operand[335:320], alu_operand[271:256],
-                                   alu_operand[207:192], alu_operand[143:128], alu_operand[79 : 64], alu_operand[15 :  0]};
-          EW32: alu_operand_seq = {alu_operand[511:480], alu_operand[447:416],
-                                   alu_operand[383:352], alu_operand[319:288],
-                                   alu_operand[255:224], alu_operand[191:160],
-                                   alu_operand[127: 96], alu_operand[63 : 32],
-                                   alu_operand[479:448], alu_operand[415:384],
-                                   alu_operand[351:320], alu_operand[287:256],
-                                   alu_operand[223:192], alu_operand[159:128],
-                                   alu_operand[95 : 64], alu_operand[31 :  0]};
-          EW64: alu_operand_seq = {alu_operand[511:448],
-                                   alu_operand[447:384],
-                                   alu_operand[383:320],
-                                   alu_operand[319:256],
-                                   alu_operand[255:192],
-                                   alu_operand[191:128],
-                                   alu_operand[127: 64],
-                                   alu_operand[63 :  0]};
-        endcase
-      end
-      16 : always_comb begin case (vinsn_issue.vtype.vsew)
-          EW8 : alu_operand_seq = {alu_operand[1023:1016], alu_operand[959:952], alu_operand[895:888], alu_operand[831:824], alu_operand[767:760], alu_operand[703:696], alu_operand[639:632], alu_operand[575:568],
-                                   alu_operand[511 : 504], alu_operand[447:440], alu_operand[383:376], alu_operand[319:312], alu_operand[255:248], alu_operand[191:184], alu_operand[127:120], alu_operand[63 : 56],
-                                   alu_operand[991 : 984], alu_operand[927:920], alu_operand[863:856], alu_operand[799:792], alu_operand[735:728], alu_operand[671:664], alu_operand[607:600], alu_operand[543:536],
-                                   alu_operand[479 : 472], alu_operand[415:408], alu_operand[351:344], alu_operand[287:280], alu_operand[223:216], alu_operand[159:152], alu_operand[95 : 88], alu_operand[31 : 24],
-                                   alu_operand[1007:1000], alu_operand[943:936], alu_operand[879:872], alu_operand[815:808], alu_operand[751:744], alu_operand[687:680], alu_operand[623:616], alu_operand[559:552],
-                                   alu_operand[495 : 488], alu_operand[431:424], alu_operand[367:360], alu_operand[303:296], alu_operand[239:232], alu_operand[175:168], alu_operand[111:104], alu_operand[47 : 40],
-                                   alu_operand[975 : 968], alu_operand[911:904], alu_operand[847:840], alu_operand[783:776], alu_operand[719:712], alu_operand[655:648], alu_operand[591:584], alu_operand[527:520],
-                                   alu_operand[463 : 456], alu_operand[399:392], alu_operand[335:328], alu_operand[271:264], alu_operand[207:200], alu_operand[143:136], alu_operand[79 : 72], alu_operand[15 :  8],
-                                   alu_operand[1015:1008], alu_operand[951:944], alu_operand[887:880], alu_operand[823:816], alu_operand[759:752], alu_operand[695:688], alu_operand[631:624], alu_operand[567:560],
-                                   alu_operand[503 : 496], alu_operand[439:432], alu_operand[375:368], alu_operand[311:304], alu_operand[247:240], alu_operand[183:176], alu_operand[119:112], alu_operand[55 : 48],
-                                   alu_operand[983 : 976], alu_operand[919:912], alu_operand[855:848], alu_operand[791:784], alu_operand[727:720], alu_operand[663:656], alu_operand[599:592], alu_operand[535:528],
-                                   alu_operand[471 : 464], alu_operand[407:400], alu_operand[343:336], alu_operand[279:272], alu_operand[215:208], alu_operand[151:144], alu_operand[87 : 80], alu_operand[23 : 16],
-                                   alu_operand[999 : 992], alu_operand[935:928], alu_operand[871:864], alu_operand[807:800], alu_operand[743:736], alu_operand[679:672], alu_operand[615:608], alu_operand[551:544],
-                                   alu_operand[487 : 480], alu_operand[423:416], alu_operand[359:352], alu_operand[295:288], alu_operand[231:224], alu_operand[167:160], alu_operand[103: 96], alu_operand[39 : 32],
-                                   alu_operand[967 : 960], alu_operand[903:896], alu_operand[839:832], alu_operand[775:768], alu_operand[711:704], alu_operand[647:640], alu_operand[583:576], alu_operand[519:512],
-                                   alu_operand[455 : 448], alu_operand[391:384], alu_operand[327:320], alu_operand[263:256], alu_operand[199:192], alu_operand[135:128], alu_operand[71 : 64], alu_operand[7  :  0]};
-          EW16: alu_operand_seq = {alu_operand[1023:1008], alu_operand[959:944], alu_operand[895:880], alu_operand[831:816],
-                                   alu_operand[767 : 752], alu_operand[703:688], alu_operand[639:624], alu_operand[575:560],
-                                   alu_operand[511 : 496], alu_operand[447:432], alu_operand[383:368], alu_operand[319:304],
-                                   alu_operand[255 : 240], alu_operand[191:176], alu_operand[127:112], alu_operand[63 : 48],
-                                   alu_operand[991 : 976], alu_operand[927:912], alu_operand[863:848], alu_operand[799:784],
-                                   alu_operand[735 : 720], alu_operand[671:656], alu_operand[607:592], alu_operand[543:528],
-                                   alu_operand[479 : 464], alu_operand[415:400], alu_operand[351:336], alu_operand[287:272],
-                                   alu_operand[223 : 208], alu_operand[159:144], alu_operand[95 : 80], alu_operand[31 : 16],
-                                   alu_operand[1007: 992], alu_operand[943:928], alu_operand[879:864], alu_operand[815:800],
-                                   alu_operand[751 : 736], alu_operand[687:672], alu_operand[623:608], alu_operand[559:544],
-                                   alu_operand[495 : 480], alu_operand[431:416], alu_operand[367:352], alu_operand[303:288],
-                                   alu_operand[239 : 224], alu_operand[175:160], alu_operand[111: 96], alu_operand[47 : 32],
-                                   alu_operand[975 : 960], alu_operand[911:896], alu_operand[847:832], alu_operand[783:768],
-                                   alu_operand[719 : 704], alu_operand[655:640], alu_operand[591:576], alu_operand[527:512],
-                                   alu_operand[463 : 448], alu_operand[399:384], alu_operand[335:320], alu_operand[271:256],
-                                   alu_operand[207 : 192], alu_operand[143:128], alu_operand[79 : 64], alu_operand[15 :  0]};
-          EW32: alu_operand_seq = {alu_operand[1023: 992], alu_operand[959:928],
-                                   alu_operand[895 : 864], alu_operand[831:800],
-                                   alu_operand[767 : 736], alu_operand[703:672],
-                                   alu_operand[639 : 608], alu_operand[575:544],
-                                   alu_operand[511 : 480], alu_operand[447:416],
-                                   alu_operand[383 : 352], alu_operand[319:288],
-                                   alu_operand[255 : 224], alu_operand[191:160],
-                                   alu_operand[127 :  96], alu_operand[63 : 32],
-                                   alu_operand[991 : 960], alu_operand[927:896],
-                                   alu_operand[863 : 832], alu_operand[799:768],
-                                   alu_operand[735 : 704], alu_operand[671:640],
-                                   alu_operand[607 : 576], alu_operand[543:512],
-                                   alu_operand[479 : 448], alu_operand[415:384],
-                                   alu_operand[351 : 320], alu_operand[287:256],
-                                   alu_operand[223 : 192], alu_operand[159:128],
-                                   alu_operand[95  :  64], alu_operand[31 :  0]};
-          EW64: alu_operand_seq = {alu_operand[1023: 960],
-                                   alu_operand[959 : 896],
-                                   alu_operand[895 : 832],
-                                   alu_operand[831 : 768],
-                                   alu_operand[767 : 704],
-                                   alu_operand[703 : 640],
-                                   alu_operand[639 : 576],
-                                   alu_operand[575 : 512],
-                                   alu_operand[511 : 448],
-                                   alu_operand[447 : 384],
-                                   alu_operand[383 : 320],
-                                   alu_operand[319 : 256],
-                                   alu_operand[255 : 192],
-                                   alu_operand[191 : 128],
-                                   alu_operand[127 :  64],
-                                   alu_operand[63  :   0]};
-        endcase
-      end
-    endcase
-  endgenerate
+  // sequencing operand_b
+  op_seq #(
+    .NrLanes(NrLanes)
+  ) i_op_b_seq (
+    .vsew             (vinsn_issue.vtype.vsew),
+    .alu_operand      (alu_operand_b         ),
+    .alu_operand_seq  (alu_operand_b_seq     )
+  );
 
-  generate
-    case (NrLanes)
-      2 : always_comb begin case (vinsn_issue.vtype.vsew)
-          EW8 : alu_result_viota_seq = {alu_result_viota_masked[127:120], alu_result_viota_masked[63:56], alu_result_viota_masked[95:88], alu_result_viota_masked[31:24], alu_result_viota_masked[111:104], alu_result_viota_masked[47:40] ,alu_result_viota_masked[79:72], alu_result_viota_masked[15:8],
-                                        alu_result_viota_masked[119:112], alu_result_viota_masked[55:48], alu_result_viota_masked[87:80], alu_result_viota_masked[23:16], alu_result_viota_masked[103: 96], alu_result_viota_masked[39:32], alu_result_viota_masked[71:64], alu_result_viota_masked[7 :0]};
-          EW16: alu_result_viota_seq = {alu_result_viota_masked[127:112], alu_result_viota_masked[63:48], alu_result_viota_masked[95:80], alu_result_viota_masked[31:16],
-                                        alu_result_viota_masked[111: 96], alu_result_viota_masked[47:32], alu_result_viota_masked[79:64], alu_result_viota_masked[15: 0]};
-          EW32: alu_result_viota_seq = {alu_result_viota_masked[127: 96], alu_result_viota_masked[63:32],
-                                        alu_result_viota_masked[95 : 64], alu_result_viota_masked[31: 0]};
-          EW64: alu_result_viota_seq = {alu_result_viota_masked[127: 64],
-                                        alu_result_viota_masked[63 :  0]};
-        endcase
-      end
-      4 : always_comb begin case (vinsn_issue.vtype.vsew)
-          EW8 : alu_result_viota_seq = {alu_result_viota_masked[255:248], alu_result_viota_masked[191:184], alu_result_viota_masked[127:120], alu_result_viota_masked[63:56], alu_result_viota_masked[223:216], alu_result_viota_masked[159:152], alu_result_viota_masked[95:88], alu_result_viota_masked[31:24],
-                                        alu_result_viota_masked[247:240], alu_result_viota_masked[183:176], alu_result_viota_masked[119:112], alu_result_viota_masked[55:48], alu_result_viota_masked[215:208], alu_result_viota_masked[151:144] ,alu_result_viota_masked[87:80], alu_result_viota_masked[23:16],
-                                        alu_result_viota_masked[239:232], alu_result_viota_masked[175:168], alu_result_viota_masked[111:104], alu_result_viota_masked[47:40], alu_result_viota_masked[207:200], alu_result_viota_masked[143:136], alu_result_viota_masked[79:72], alu_result_viota_masked[15: 8],
-                                        alu_result_viota_masked[231:224], alu_result_viota_masked[167:160], alu_result_viota_masked[103: 96], alu_result_viota_masked[39:32], alu_result_viota_masked[199:192], alu_result_viota_masked[135:128], alu_result_viota_masked[71:64], alu_result_viota_masked[7 : 0]};
-          EW16: alu_result_viota_seq = {alu_result_viota_masked[255:240], alu_result_viota_masked[191:176], alu_result_viota_masked[127:112], alu_result_viota_masked[63:48],
-                                        alu_result_viota_masked[223:208], alu_result_viota_masked[159:144], alu_result_viota_masked[95 : 80], alu_result_viota_masked[31:16],
-                                        alu_result_viota_masked[239:224], alu_result_viota_masked[175:160], alu_result_viota_masked[111: 96], alu_result_viota_masked[47:32],
-                                        alu_result_viota_masked[207:192], alu_result_viota_masked[143:128], alu_result_viota_masked[79 : 64], alu_result_viota_masked[15: 0]};
-          EW32: alu_result_viota_seq = {alu_result_viota_masked[255:224], alu_result_viota_masked[191:160],
-                                        alu_result_viota_masked[127: 96], alu_result_viota_masked[63 : 32],
-                                        alu_result_viota_masked[223:192], alu_result_viota_masked[159:128],
-                                        alu_result_viota_masked[95 : 64], alu_result_viota_masked[31 :  0]};
-          EW64: alu_result_viota_seq = {alu_result_viota_masked[255:192],
-                                        alu_result_viota_masked[191:128],
-                                        alu_result_viota_masked[127: 64],
-                                        alu_result_viota_masked[63 :  0]};
-        endcase
-      end
-      8 : always_comb begin case (vinsn_issue.vtype.vsew)
-          EW8 : alu_result_viota_seq = {alu_result_viota_masked[511:504], alu_result_viota_masked[447:440], alu_result_viota_masked[383:376], alu_result_viota_masked[319:312], alu_result_viota_masked[255:248], alu_result_viota_masked[191:184], alu_result_viota_masked[127:120], alu_result_viota_masked[63:56],
-                                        alu_result_viota_masked[503:496], alu_result_viota_masked[439:432], alu_result_viota_masked[375:368], alu_result_viota_masked[311:304], alu_result_viota_masked[247:240], alu_result_viota_masked[183:176], alu_result_viota_masked[119:112], alu_result_viota_masked[55:48],
-                                        alu_result_viota_masked[495:488], alu_result_viota_masked[431:424], alu_result_viota_masked[367:360], alu_result_viota_masked[303:296], alu_result_viota_masked[239:232], alu_result_viota_masked[175:168], alu_result_viota_masked[111:104], alu_result_viota_masked[47:40],
-                                        alu_result_viota_masked[487:480], alu_result_viota_masked[423:416], alu_result_viota_masked[359:352], alu_result_viota_masked[295:288], alu_result_viota_masked[231:224], alu_result_viota_masked[167:160], alu_result_viota_masked[103: 96], alu_result_viota_masked[39:32],
-                                        alu_result_viota_masked[479:472], alu_result_viota_masked[415:408], alu_result_viota_masked[351:344], alu_result_viota_masked[287:280], alu_result_viota_masked[223:216], alu_result_viota_masked[159:152], alu_result_viota_masked[95 : 88], alu_result_viota_masked[31:24],
-                                        alu_result_viota_masked[471:464], alu_result_viota_masked[407:400], alu_result_viota_masked[343:336], alu_result_viota_masked[279:272], alu_result_viota_masked[215:208], alu_result_viota_masked[151:144], alu_result_viota_masked[87 : 80], alu_result_viota_masked[23:16],
-                                        alu_result_viota_masked[463:456], alu_result_viota_masked[399:392], alu_result_viota_masked[335:328], alu_result_viota_masked[271:264], alu_result_viota_masked[207:200], alu_result_viota_masked[143:136], alu_result_viota_masked[79 : 72], alu_result_viota_masked[15: 8],
-                                        alu_result_viota_masked[455:448], alu_result_viota_masked[391:384], alu_result_viota_masked[327:320], alu_result_viota_masked[263:256], alu_result_viota_masked[199:192], alu_result_viota_masked[135:128], alu_result_viota_masked[71 : 64], alu_result_viota_masked[7 : 0]};
-          EW16: alu_result_viota_seq = {alu_result_viota_masked[511:496], alu_result_viota_masked[447:432], alu_result_viota_masked[383:368], alu_result_viota_masked[319:304],
-                                        alu_result_viota_masked[255:240], alu_result_viota_masked[191:176], alu_result_viota_masked[127:112], alu_result_viota_masked[63 : 48],
-                                        alu_result_viota_masked[479:464], alu_result_viota_masked[415:400], alu_result_viota_masked[351:336], alu_result_viota_masked[287:272],
-                                        alu_result_viota_masked[223:208], alu_result_viota_masked[159:144], alu_result_viota_masked[95 : 80], alu_result_viota_masked[31 : 16],
-                                        alu_result_viota_masked[495:480], alu_result_viota_masked[431:416], alu_result_viota_masked[367:352], alu_result_viota_masked[303:288],
-                                        alu_result_viota_masked[239:224], alu_result_viota_masked[175:160], alu_result_viota_masked[111: 96], alu_result_viota_masked[47 : 32],
-                                        alu_result_viota_masked[463:448], alu_result_viota_masked[399:384], alu_result_viota_masked[335:320], alu_result_viota_masked[271:256],
-                                        alu_result_viota_masked[207:192], alu_result_viota_masked[143:128], alu_result_viota_masked[79 : 64], alu_result_viota_masked[15 :  0]};
-          EW32: alu_result_viota_seq = {alu_result_viota_masked[511:480], alu_result_viota_masked[447:416],
-                                        alu_result_viota_masked[383:352], alu_result_viota_masked[319:288],
-                                        alu_result_viota_masked[255:224], alu_result_viota_masked[191:160],
-                                        alu_result_viota_masked[127: 96], alu_result_viota_masked[63 : 32],
-                                        alu_result_viota_masked[479:448], alu_result_viota_masked[415:384],
-                                        alu_result_viota_masked[351:320], alu_result_viota_masked[287:256],
-                                        alu_result_viota_masked[223:192], alu_result_viota_masked[159:128],
-                                        alu_result_viota_masked[95 : 64], alu_result_viota_masked[31 :  0]};
-          EW64: alu_result_viota_seq = {alu_result_viota_masked[511:448],
-                                        alu_result_viota_masked[447:384],
-                                        alu_result_viota_masked[383:320],
-                                        alu_result_viota_masked[319:256],
-                                        alu_result_viota_masked[255:192],
-                                        alu_result_viota_masked[191:128],
-                                        alu_result_viota_masked[127: 64],
-                                        alu_result_viota_masked[63 :  0]};
-        endcase
-      end
-      16 : always_comb begin case (vinsn_issue.vtype.vsew)
-          EW8 : alu_result_viota_seq = {alu_result_viota_masked[1023:1016], alu_result_viota_masked[959:952], alu_result_viota_masked[895:888], alu_result_viota_masked[831:824], alu_result_viota_masked[767:760], alu_result_viota_masked[703:696], alu_result_viota_masked[639:632], alu_result_viota_masked[575:568],
-                                        alu_result_viota_masked[1015:1008], alu_result_viota_masked[951:944], alu_result_viota_masked[887:880], alu_result_viota_masked[823:816], alu_result_viota_masked[759:752], alu_result_viota_masked[695:688], alu_result_viota_masked[631:624], alu_result_viota_masked[567:560],
-                                        alu_result_viota_masked[1007:1000], alu_result_viota_masked[943:936], alu_result_viota_masked[879:872], alu_result_viota_masked[815:808], alu_result_viota_masked[751:744], alu_result_viota_masked[687:680], alu_result_viota_masked[623:616], alu_result_viota_masked[559:552],
-                                        alu_result_viota_masked[999 : 992], alu_result_viota_masked[935:928], alu_result_viota_masked[871:864], alu_result_viota_masked[807:800], alu_result_viota_masked[743:736], alu_result_viota_masked[679:672], alu_result_viota_masked[615:608], alu_result_viota_masked[551:544],
-                                        alu_result_viota_masked[991 : 984], alu_result_viota_masked[927:920], alu_result_viota_masked[863:856], alu_result_viota_masked[799:792], alu_result_viota_masked[735:728], alu_result_viota_masked[671:664], alu_result_viota_masked[607:600], alu_result_viota_masked[543:536],
-                                        alu_result_viota_masked[983 : 976], alu_result_viota_masked[919:912], alu_result_viota_masked[855:848], alu_result_viota_masked[791:784], alu_result_viota_masked[727:720], alu_result_viota_masked[663:656], alu_result_viota_masked[599:592], alu_result_viota_masked[535:528],
-                                        alu_result_viota_masked[975 : 968], alu_result_viota_masked[911:904], alu_result_viota_masked[847:840], alu_result_viota_masked[783:776], alu_result_viota_masked[719:712], alu_result_viota_masked[655:648], alu_result_viota_masked[591:584], alu_result_viota_masked[527:520],
-                                        alu_result_viota_masked[967 : 960], alu_result_viota_masked[903:896], alu_result_viota_masked[839:832], alu_result_viota_masked[775:768], alu_result_viota_masked[711:704], alu_result_viota_masked[647:640], alu_result_viota_masked[583:576], alu_result_viota_masked[519:512],
-                                        alu_result_viota_masked[511 : 504], alu_result_viota_masked[447:440], alu_result_viota_masked[383:376], alu_result_viota_masked[319:312], alu_result_viota_masked[255:248], alu_result_viota_masked[191:184], alu_result_viota_masked[127:120], alu_result_viota_masked[63 : 56],
-                                        alu_result_viota_masked[503 : 496], alu_result_viota_masked[439:432], alu_result_viota_masked[375:368], alu_result_viota_masked[311:304], alu_result_viota_masked[247:240], alu_result_viota_masked[183:176], alu_result_viota_masked[119:112], alu_result_viota_masked[55 : 48],
-                                        alu_result_viota_masked[495 : 488], alu_result_viota_masked[431:424], alu_result_viota_masked[367:360], alu_result_viota_masked[303:296], alu_result_viota_masked[239:232], alu_result_viota_masked[175:168], alu_result_viota_masked[111:104], alu_result_viota_masked[47 : 40],
-                                        alu_result_viota_masked[487 : 480], alu_result_viota_masked[423:416], alu_result_viota_masked[359:352], alu_result_viota_masked[295:288], alu_result_viota_masked[231:224], alu_result_viota_masked[167:160], alu_result_viota_masked[103: 96], alu_result_viota_masked[39 : 32],
-                                        alu_result_viota_masked[479 : 472], alu_result_viota_masked[415:408], alu_result_viota_masked[351:344], alu_result_viota_masked[287:280], alu_result_viota_masked[223:216], alu_result_viota_masked[159:152], alu_result_viota_masked[95 : 88], alu_result_viota_masked[31 : 24],
-                                        alu_result_viota_masked[471 : 464], alu_result_viota_masked[407:400], alu_result_viota_masked[343:336], alu_result_viota_masked[279:272], alu_result_viota_masked[215:208], alu_result_viota_masked[151:144], alu_result_viota_masked[87 : 80], alu_result_viota_masked[23 : 16],
-                                        alu_result_viota_masked[463 : 456], alu_result_viota_masked[399:392], alu_result_viota_masked[335:328], alu_result_viota_masked[271:264], alu_result_viota_masked[207:200], alu_result_viota_masked[143:136], alu_result_viota_masked[79 : 72], alu_result_viota_masked[15 :  8],
-                                        alu_result_viota_masked[455 : 448], alu_result_viota_masked[391:384], alu_result_viota_masked[327:320], alu_result_viota_masked[263:256], alu_result_viota_masked[199:192], alu_result_viota_masked[135:128], alu_result_viota_masked[71 : 64], alu_result_viota_masked[7  :  0]};
-          EW16: alu_result_viota_seq = {alu_result_viota_masked[1023:1008], alu_result_viota_masked[959:944], alu_result_viota_masked[895:880], alu_result_viota_masked[831:816],
-                                        alu_result_viota_masked[767 : 752], alu_result_viota_masked[703:688], alu_result_viota_masked[639:624], alu_result_viota_masked[575:560],
-                                        alu_result_viota_masked[511 : 496], alu_result_viota_masked[447:432], alu_result_viota_masked[383:368], alu_result_viota_masked[319:304],
-                                        alu_result_viota_masked[255 : 240], alu_result_viota_masked[191:176], alu_result_viota_masked[127:112], alu_result_viota_masked[63 : 48],
-                                        alu_result_viota_masked[991 : 976], alu_result_viota_masked[927:912], alu_result_viota_masked[863:848], alu_result_viota_masked[799:784],
-                                        alu_result_viota_masked[735 : 720], alu_result_viota_masked[671:656], alu_result_viota_masked[607:592], alu_result_viota_masked[543:528],
-                                        alu_result_viota_masked[479 : 464], alu_result_viota_masked[415:400], alu_result_viota_masked[351:336], alu_result_viota_masked[287:272],
-                                        alu_result_viota_masked[223 : 208], alu_result_viota_masked[159:144], alu_result_viota_masked[95 : 80], alu_result_viota_masked[31 : 16],
-                                        alu_result_viota_masked[1007: 992], alu_result_viota_masked[943:928], alu_result_viota_masked[879:864], alu_result_viota_masked[815:800],
-                                        alu_result_viota_masked[751 : 736], alu_result_viota_masked[687:672], alu_result_viota_masked[623:608], alu_result_viota_masked[559:544],
-                                        alu_result_viota_masked[495 : 480], alu_result_viota_masked[431:416], alu_result_viota_masked[367:352], alu_result_viota_masked[303:288],
-                                        alu_result_viota_masked[239 : 224], alu_result_viota_masked[175:160], alu_result_viota_masked[111: 96], alu_result_viota_masked[47 : 32],
-                                        alu_result_viota_masked[975 : 960], alu_result_viota_masked[911:896], alu_result_viota_masked[847:832], alu_result_viota_masked[783:768],
-                                        alu_result_viota_masked[719 : 704], alu_result_viota_masked[655:640], alu_result_viota_masked[591:576], alu_result_viota_masked[527:512],
-                                        alu_result_viota_masked[463 : 448], alu_result_viota_masked[399:384], alu_result_viota_masked[335:320], alu_result_viota_masked[271:256],
-                                        alu_result_viota_masked[207 : 192], alu_result_viota_masked[143:128], alu_result_viota_masked[79 : 64], alu_result_viota_masked[15 :  0]};
-          EW32: alu_result_viota_seq = {alu_result_viota_masked[1023: 992], alu_result_viota_masked[959:928],
-                                        alu_result_viota_masked[895 : 864], alu_result_viota_masked[831:800],
-                                        alu_result_viota_masked[767 : 736], alu_result_viota_masked[703:672],
-                                        alu_result_viota_masked[639 : 608], alu_result_viota_masked[575:544],
-                                        alu_result_viota_masked[511 : 480], alu_result_viota_masked[447:416],
-                                        alu_result_viota_masked[383 : 352], alu_result_viota_masked[319:288],
-                                        alu_result_viota_masked[255 : 224], alu_result_viota_masked[191:160],
-                                        alu_result_viota_masked[127 :  96], alu_result_viota_masked[63 : 32],
-                                        alu_result_viota_masked[991 : 960], alu_result_viota_masked[927:896],
-                                        alu_result_viota_masked[863 : 832], alu_result_viota_masked[799:768],
-                                        alu_result_viota_masked[735 : 704], alu_result_viota_masked[671:640],
-                                        alu_result_viota_masked[607 : 576], alu_result_viota_masked[543:512],
-                                        alu_result_viota_masked[479 : 448], alu_result_viota_masked[415:384],
-                                        alu_result_viota_masked[351 : 320], alu_result_viota_masked[287:256],
-                                        alu_result_viota_masked[223 : 192], alu_result_viota_masked[159:128],
-                                        alu_result_viota_masked[95  :  64], alu_result_viota_masked[31 :  0]};
-          EW64: alu_result_viota_seq = {alu_result_viota_masked[1023: 960],
-                                        alu_result_viota_masked[959 : 896],
-                                        alu_result_viota_masked[895 : 832],
-                                        alu_result_viota_masked[831 : 768],
-                                        alu_result_viota_masked[767 : 704],
-                                        alu_result_viota_masked[703 : 640],
-                                        alu_result_viota_masked[639 : 576],
-                                        alu_result_viota_masked[575 : 512],
-                                        alu_result_viota_masked[511 : 448],
-                                        alu_result_viota_masked[447 : 384],
-                                        alu_result_viota_masked[383 : 320],
-                                        alu_result_viota_masked[319 : 256],
-                                        alu_result_viota_masked[255 : 192],
-                                        alu_result_viota_masked[191 : 128],
-                                        alu_result_viota_masked[127 :  64],
-                                        alu_result_viota_masked[63  :   0]};
-        endcase
-      end
-    endcase
-  endgenerate
+  // sequencing final result (to be written to VRF)
+  res_seq #(
+    .NrLanes(NrLanes)
+  ) i_res_seq (
+    .vsew             (vinsn_issue.vtype.vsew),
+    .alu_result       (alu_result_vm_m       ),
+    .alu_result_seq   (alu_result_vm_seq     )
+  );
 
   always_comb begin: p_mask_alu
     alu_result         = '0;
     bit_enable         = '0;
     bit_enable_shuffle = '0;
     bit_enable_mask    = '0;
-    alu_result_mask    = '0;
-    alu_result_viota   = '0;
+    alu_result_vm      = '0;
 
     vcpop_to_count     = '0;
 
@@ -646,86 +392,26 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
         end
       end
 
+      // Mask generation
+      unique case (vinsn_issue.op) inside
+        [VMSBF:VID] :
+          unique case (vinsn_issue.vtype.vsew)
+            EW8 : for (int i = 0; i < (DataWidth * NrLanes)/8; i++)
+                    mask [(i*8) +: 8]   = {8{bit_enable_mask [i]}};
+            EW16: for (int i = 0; i < (DataWidth * NrLanes)/16; i++)
+                    mask [(i*16) +: 16] = {16{bit_enable_mask [i]}};
+            EW32: for (int i = 0; i < (DataWidth * NrLanes)/32; i++)
+                    mask [(i*32) +: 32] = {32{bit_enable_mask [i]}};
+            EW64: for (int i = 0; i < (DataWidth * NrLanes)/64; i++)
+                    mask [(i*64) +: 64] = {64{bit_enable_mask [i]}};
+          endcase
+        default:;
+      endcase
+
       // Evaluate the instruction
       unique case (vinsn_issue.op) inside
-        [VMANDNOT:VMNOR]: alu_result = (masku_operand_a_i & bit_enable_mask) |
+        [VMANDN:VMNOR], VMXNOR: alu_result = (masku_operand_a_i & bit_enable_mask) |
           (masku_operand_b_i & ~bit_enable_mask);
-        [VMSBF:VMSIF] : begin
-          if (alu_operand_valid_i) begin
-              for (int i = 0; i < NrLanes * DataWidth; i++) begin
-                  if (alu_operand_seq[i] == 1'b0) begin
-                      alu_result_mask[i] = (vinsn_issue.op == VMSOF) ? 1'b0 : 1'b1;
-                  end else begin
-                      alu_result_mask[i] = (vinsn_issue.op == VMSBF) ? 1'b0 : 1'b1;
-                      i = NrLanes * DataWidth;
-                  end
-              end
-          end
-        end
-        VMXNOR: alu_result = (masku_operand_a_i & bit_enable_mask) |
-          (masku_operand_b_i & ~bit_enable_mask);
-        VIOTA: begin
-          be_id = 64'd18446744073709551615;
-          unique case (vinsn_issue.vtype.vsew)
-            EW8 : begin
-              alu_operand_seq_masked = alu_operand_seq & {{8{|bit_enable_mask[7]}},{8{|bit_enable_mask[6]}},{8{|bit_enable_mask[5]}},{8{|bit_enable_mask[4]}},{8{|bit_enable_mask[3]}},{8{|bit_enable_mask[2]}},{8{|bit_enable_mask[1]}},{8{|bit_enable_mask[0]}}};
-              for (int index = 1; index < (NrLanes*DataWidth)/8; index++) begin
-                alu_result_viota [(index*8) +: 7] = alu_operand_seq_masked [((index-1)*8) +: 7] + alu_result_viota [((index-1)*8) +: 7];
-                alu_result_viota_masked = alu_result_viota & {{8{|bit_enable_mask[7]}},{8{|bit_enable_mask[6]}},{8{|bit_enable_mask[5]}},{8{|bit_enable_mask[4]}},{8{|bit_enable_mask[3]}},{8{|bit_enable_mask[2]}},{8{|bit_enable_mask[1]}},{8{|bit_enable_mask[0]}}};
-              end
-            end
-            EW16: begin
-              alu_operand_seq_masked = alu_operand_seq & {{16{|bit_enable_mask[7]}},{16{|bit_enable_mask[6]}},{16{|bit_enable_mask[5]}},{16{|bit_enable_mask[4]}},{16{|bit_enable_mask[3]}},{16{|bit_enable_mask[2]}},{16{|bit_enable_mask[1]}},{16{|bit_enable_mask[0]}}};
-              for (int index = 1; index < (NrLanes*DataWidth)/16; index++) begin
-                alu_result_viota [(index*16) +: 15] = alu_operand_seq_masked [((index-1)*16) +: 15] + alu_result_viota [((index-1)*16) +: 15];
-                alu_result_viota_masked = alu_result_viota & {{16{|bit_enable_mask[7]}},{16{|bit_enable_mask[6]}},{16{|bit_enable_mask[5]}},{16{|bit_enable_mask[4]}},{16{|bit_enable_mask[3]}},{16{|bit_enable_mask[2]}},{16{|bit_enable_mask[1]}},{16{|bit_enable_mask[0]}}};
-              end
-            end
-            EW32: begin
-              alu_operand_seq_masked = alu_operand_seq & {{32{|bit_enable_mask[7]}},{32{|bit_enable_mask[6]}},{32{|bit_enable_mask[5]}},{32{|bit_enable_mask[4]}},{32{|bit_enable_mask[3]}},{32{|bit_enable_mask[2]}},{32{|bit_enable_mask[1]}},{32{|bit_enable_mask[0]}}};
-              for (int index = 1; index < (NrLanes*DataWidth)/32; index++) begin
-                alu_result_viota [(index*32) +: 31] = alu_operand_seq_masked [((index-1)*32) +: 31] + alu_result_viota [((index-1)*32) +: 31];
-                alu_result_viota_masked = alu_result_viota & {{32{|bit_enable_mask[7]}},{32{|bit_enable_mask[6]}},{32{|bit_enable_mask[5]}},{32{|bit_enable_mask[4]}},{32{|bit_enable_mask[3]}},{32{|bit_enable_mask[2]}},{32{|bit_enable_mask[1]}},{32{|bit_enable_mask[0]}}};
-              end
-            end
-            EW64: begin
-              alu_operand_seq_masked = alu_operand_seq & {{64{|bit_enable_mask[7]}},{64{|bit_enable_mask[6]}},{64{|bit_enable_mask[5]}},{64{|bit_enable_mask[4]}},{64{|bit_enable_mask[3]}},{64{|bit_enable_mask[2]}},{64{|bit_enable_mask[1]}},{64{|bit_enable_mask[0]}}};
-              for (int index = 1; index < (NrLanes*DataWidth)/64; index++) begin
-                alu_result_viota [(index*64) +: 63] = alu_operand_seq_masked [((index-1)*64) +: 63] + alu_result_viota [((index-1)*64) +: 63];
-                alu_result_viota_masked = alu_result_viota & {{64{|bit_enable_mask[7]}},{64{|bit_enable_mask[6]}},{64{|bit_enable_mask[5]}},{64{|bit_enable_mask[4]}},{64{|bit_enable_mask[3]}},{64{|bit_enable_mask[2]}},{64{|bit_enable_mask[1]}},{64{|bit_enable_mask[0]}}};
-              end
-            end
-          endcase
-        end
-        VID: begin
-          be_id = 64'd18446744073709551615;
-          unique case (vinsn_issue.vtype.vsew)
-            EW8 : begin
-              for (int index = 1; index < (NrLanes*DataWidth)/8; index++) begin
-                alu_result_viota [(index*8) +: 7] = index;
-                alu_result_viota_masked = alu_result_viota & {{8{|bit_enable_mask[7]}},{8{|bit_enable_mask[6]}},{8{|bit_enable_mask[5]}},{8{|bit_enable_mask[4]}},{8{|bit_enable_mask[3]}},{8{|bit_enable_mask[2]}},{8{|bit_enable_mask[1]}},{8{|bit_enable_mask[0]}}};
-              end
-            end
-            EW16: begin
-              for (int index = 1; index < (NrLanes*DataWidth)/16; index++) begin
-                alu_result_viota [(index*16) +: 15] = index;
-                alu_result_viota_masked = alu_result_viota & {{16{|bit_enable_mask[7]}},{16{|bit_enable_mask[6]}},{16{|bit_enable_mask[5]}},{16{|bit_enable_mask[4]}},{16{|bit_enable_mask[3]}},{16{|bit_enable_mask[2]}},{16{|bit_enable_mask[1]}},{16{|bit_enable_mask[0]}}};
-              end
-            end
-            EW32: begin
-              for (int index = 1; index < (NrLanes*DataWidth)/32; index++) begin
-                alu_result_viota [(index*32) +: 31] = index;
-                alu_result_viota_masked = alu_result_viota & {{32{|bit_enable_mask[7]}},{32{|bit_enable_mask[6]}},{32{|bit_enable_mask[5]}},{32{|bit_enable_mask[4]}},{32{|bit_enable_mask[3]}},{32{|bit_enable_mask[2]}},{32{|bit_enable_mask[1]}},{32{|bit_enable_mask[0]}}};
-              end
-            end
-            EW64: begin
-              for (int index = 1; index < (NrLanes*DataWidth)/64; index++) begin
-                alu_result_viota [(index*64) +: 63] = index;
-                alu_result_viota_masked = alu_result_viota & {{64{|bit_enable_mask[7]}},{64{|bit_enable_mask[6]}},{64{|bit_enable_mask[5]}},{64{|bit_enable_mask[4]}},{64{|bit_enable_mask[3]}},{64{|bit_enable_mask[2]}},{64{|bit_enable_mask[1]}},{64{|bit_enable_mask[0]}}};
-              end
-            end
-          endcase
-        end
         [VMFEQ:VMSBC] : begin
           automatic logic [ELEN*NrLanes-1:0] alu_result_flat = '0;
 
@@ -810,6 +496,77 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
         end
         VFIRST : begin
           vfirst_to_count = masku_operand_b_i & bit_enable_mask;
+        [VMSBF:VMSIF] : begin
+          if (alu_operand_b_valid_i) begin
+              for (int i = 0; i < NrLanes * DataWidth; i++) begin
+                  if (alu_operand_b_seq[i] == 1'b0) begin
+                      alu_result_vm[i] = (vinsn_issue.op == VMSOF) ? 1'b0 : 1'b1;
+                  end else begin
+                      alu_result_vm[i] = (vinsn_issue.op == VMSBF) ? 1'b0 : 1'b1;
+                      i = NrLanes * DataWidth;
+                  end
+              end
+          end
+        end
+        VIOTA: begin
+          unique case (vinsn_issue.vtype.vsew)
+            EW8 : begin
+              alu_operand_b_seq_m = alu_operand_b_seq & mask;
+              for (int index = 1; index < (NrLanes*DataWidth)/8; index++) begin
+                alu_result_vm [(index*8) +: 7] = alu_operand_b_seq_m [((index-1)*8) +: 7] + alu_result_vm [((index-1)*8) +: 7];
+                alu_result_vm_m = alu_result_vm & mask;
+              end
+            end
+            EW16: begin
+              alu_operand_b_seq_m = alu_operand_b_seq & mask;
+              for (int index = 1; index < (NrLanes*DataWidth)/16; index++) begin
+                alu_result_vm [(index*16) +: 15] = alu_operand_b_seq_m [((index-1)*16) +: 15] + alu_result_vm [((index-1)*16) +: 15];
+                alu_result_vm_m = alu_result_vm & mask;
+              end
+            end
+            EW32: begin
+              alu_operand_b_seq_m = alu_operand_b_seq & mask;
+              for (int index = 1; index < (NrLanes*DataWidth)/32; index++) begin
+                alu_result_vm [(index*32) +: 31] = alu_operand_b_seq_m [((index-1)*32) +: 31] + alu_result_vm [((index-1)*32) +: 31];
+                alu_result_vm_m = alu_result_vm & mask;
+              end
+            end
+            EW64: begin
+              alu_operand_b_seq_m = alu_operand_b_seq & mask;
+              for (int index = 1; index < (NrLanes*DataWidth)/64; index++) begin
+                alu_result_vm [(index*64) +: 63] = alu_operand_b_seq_m [((index-1)*64) +: 63] + alu_result_vm [((index-1)*64) +: 63];
+                alu_result_vm_m = alu_result_vm & mask;
+              end
+            end
+          endcase
+        end
+        VID: begin
+          unique case (vinsn_issue.vtype.vsew)
+            EW8 : begin
+              for (int index = 1; index < (NrLanes*DataWidth)/8; index++) begin
+                alu_result_vm [(index*8) +: 7] = index;
+                alu_result_vm_m = alu_result_vm & mask;
+              end
+            end
+            EW16: begin
+              for (int index = 1; index < (NrLanes*DataWidth)/16; index++) begin
+                alu_result_vm [(index*16) +: 15] = index;
+                alu_result_vm_m = alu_result_vm & mask;
+              end
+            end
+            EW32: begin
+              for (int index = 1; index < (NrLanes*DataWidth)/32; index++) begin
+                alu_result_vm [(index*32) +: 31] = index;
+                alu_result_vm_m = alu_result_vm & mask;
+              end
+            end
+            EW64: begin
+              for (int index = 1; index < (NrLanes*DataWidth)/64; index++) begin
+                alu_result_vm [(index*64) +: 63] = index;
+                alu_result_vm_m = alu_result_vm & mask;
+              end
+            end
+          endcase
         end
         default: alu_result = '0;
       endcase
@@ -1015,7 +772,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
 
             result_queue_d[result_queue_write_pnt_q][lane] = '{
               wdata: (vinsn_issue.op inside {[VMSBF:VMSIF]}) ? result_queue_q[result_queue_write_pnt_q][lane].wdata | alu_result_ff[lane] : (vinsn_issue.op inside {[VIOTA:VID]}) ? result_queue_q[result_queue_write_pnt_q][lane].wdata | alu_result_f[lane] : result_queue_q[result_queue_write_pnt_q][lane].wdata | alu_result[lane],
-              be   : (vinsn_issue.op inside {[VIOTA:  VID]}) ? be_id[lane] : be(element_cnt, vinsn_issue.vtype.vsew),
+              be   : (vinsn_issue.op inside {[VIOTA:  VID]}) ? '1 : be(element_cnt, vinsn_issue.vtype.vsew),
               addr : vaddr(vinsn_issue.vd, NrLanes) +
                 (((vinsn_issue.vl - issue_cnt_q) / NrLanes / DataWidth)),
               id : vinsn_issue.id

--- a/hardware/src/masku/seq_modules/op_seq.sv
+++ b/hardware/src/masku/seq_modules/op_seq.sv
@@ -1,0 +1,158 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Muhammad Ijaz
+// Description:
+// This is Ara's operand sequencer module, which is responsible for sequencing the operand recieved from lane_sequencer
+
+
+module op_seq import ara_pkg::*; import rvv_pkg::*; #(
+    parameter  int  unsigned NrLanes = 0,
+    // Dependant parameters. DO NOT CHANGE!
+    localparam int  unsigned DataWidth = $bits(elen_t) // Width of the lane datapath
+  ) (
+    // Interface with the masku
+    input  logic [3:0]                                 vsew,
+    input  logic [NrLanes*DataWidth-1:0]               alu_operand,
+    output logic [NrLanes*DataWidth-1:0]               alu_operand_seq
+  );
+
+  generate
+    case (NrLanes)
+      2 : always_comb begin case (vsew)
+          EW8 : alu_operand_seq = {alu_operand[127:120], alu_operand[63:56], alu_operand[111:104], alu_operand[47:40], alu_operand[95 :88], alu_operand[31:24] ,alu_operand[79:72], alu_operand[15:8],
+                                   alu_operand[119:112], alu_operand[55:48], alu_operand[87 : 80], alu_operand[23:16], alu_operand[103:96], alu_operand[39:32], alu_operand[71:64], alu_operand[7 :0]};
+          EW16: alu_operand_seq = {alu_operand[127:112], alu_operand[63:48], alu_operand[95 : 80], alu_operand[31:16],
+                                   alu_operand[111: 96], alu_operand[47:32], alu_operand[79 : 64], alu_operand[15: 0]};
+          EW32: alu_operand_seq = {alu_operand[127: 96], alu_operand[63:32],
+                                   alu_operand[95 : 64], alu_operand[31: 0]};
+          EW64: alu_operand_seq = {alu_operand[127: 64],
+                                   alu_operand[63 :  0]};
+        endcase
+      end
+      4 : always_comb begin case (vsew)
+          EW8 : alu_operand_seq = {alu_operand[255:248], alu_operand[191:184], alu_operand[127:120], alu_operand[63:56], alu_operand[223:216], alu_operand[159:152], alu_operand[95:88], alu_operand[31:24],
+                                   alu_operand[239:232], alu_operand[175:168], alu_operand[111:104], alu_operand[47:40], alu_operand[207:200], alu_operand[143:136], alu_operand[79:72], alu_operand[15: 8],
+                                   alu_operand[247:240], alu_operand[183:176], alu_operand[119:112], alu_operand[55:48], alu_operand[215:208], alu_operand[151:144] ,alu_operand[87:80], alu_operand[23:16],
+                                   alu_operand[231:224], alu_operand[167:160], alu_operand[103: 96], alu_operand[39:32], alu_operand[199:192], alu_operand[135:128], alu_operand[71:64], alu_operand[7 : 0]};
+          EW16: alu_operand_seq = {alu_operand[255:240], alu_operand[191:176], alu_operand[127:112], alu_operand[63:48],
+                                   alu_operand[223:208], alu_operand[159:144], alu_operand[95 : 80], alu_operand[31:16],
+                                   alu_operand[239:224], alu_operand[175:160], alu_operand[111: 96], alu_operand[47:32],
+                                   alu_operand[207:192], alu_operand[143:128], alu_operand[79 : 64], alu_operand[15: 0]};
+          EW32: alu_operand_seq = {alu_operand[255:224], alu_operand[191:160],
+                                   alu_operand[127: 96], alu_operand[63 : 32],
+                                   alu_operand[223:192], alu_operand[159:128],
+                                   alu_operand[95 : 64], alu_operand[31 :  0]};
+          EW64: alu_operand_seq = {alu_operand[255:192],
+                                   alu_operand[191:128],
+                                   alu_operand[127: 64],
+                                   alu_operand[63 :  0]};
+        endcase
+      end
+      8 : always_comb begin case (vsew)
+          EW8 : alu_operand_seq = {alu_operand[511:504], alu_operand[447:440], alu_operand[383:376], alu_operand[319:312], alu_operand[255:248], alu_operand[191:184], alu_operand[127:120], alu_operand[63:56],
+                                   alu_operand[479:472], alu_operand[415:408], alu_operand[351:344], alu_operand[287:280], alu_operand[223:216], alu_operand[159:152], alu_operand[95 : 88], alu_operand[31:24],
+                                   alu_operand[495:488], alu_operand[431:424], alu_operand[367:360], alu_operand[303:296], alu_operand[239:232], alu_operand[175:168], alu_operand[111:104], alu_operand[47:40],
+                                   alu_operand[463:456], alu_operand[399:392], alu_operand[335:328], alu_operand[271:264], alu_operand[207:200], alu_operand[143:136], alu_operand[79 : 72], alu_operand[15: 8],
+                                   alu_operand[503:496], alu_operand[439:432], alu_operand[375:368], alu_operand[311:304], alu_operand[247:240], alu_operand[183:176], alu_operand[119:112], alu_operand[55:48],
+                                   alu_operand[471:464], alu_operand[407:400], alu_operand[343:336], alu_operand[279:272], alu_operand[215:208], alu_operand[151:144], alu_operand[87 : 80], alu_operand[23:16],
+                                   alu_operand[487:480], alu_operand[423:416], alu_operand[359:352], alu_operand[295:288], alu_operand[231:224], alu_operand[167:160], alu_operand[103: 96], alu_operand[39:32],
+                                   alu_operand[455:448], alu_operand[391:384], alu_operand[327:320], alu_operand[263:256], alu_operand[199:192], alu_operand[135:128], alu_operand[71 : 64], alu_operand[7 : 0]};
+          EW16: alu_operand_seq = {alu_operand[511:496], alu_operand[447:432], alu_operand[383:368], alu_operand[319:304],
+                                   alu_operand[255:240], alu_operand[191:176], alu_operand[127:112], alu_operand[63 : 48],
+                                   alu_operand[479:464], alu_operand[415:400], alu_operand[351:336], alu_operand[287:272],
+                                   alu_operand[223:208], alu_operand[159:144], alu_operand[95 : 80], alu_operand[31 : 16],
+                                   alu_operand[495:480], alu_operand[431:416], alu_operand[367:352], alu_operand[303:288],
+                                   alu_operand[239:224], alu_operand[175:160], alu_operand[111: 96], alu_operand[47 : 32],
+                                   alu_operand[463:448], alu_operand[399:384], alu_operand[335:320], alu_operand[271:256],
+                                   alu_operand[207:192], alu_operand[143:128], alu_operand[79 : 64], alu_operand[15 :  0]};
+          EW32: alu_operand_seq = {alu_operand[511:480], alu_operand[447:416],
+                                   alu_operand[383:352], alu_operand[319:288],
+                                   alu_operand[255:224], alu_operand[191:160],
+                                   alu_operand[127: 96], alu_operand[63 : 32],
+                                   alu_operand[479:448], alu_operand[415:384],
+                                   alu_operand[351:320], alu_operand[287:256],
+                                   alu_operand[223:192], alu_operand[159:128],
+                                   alu_operand[95 : 64], alu_operand[31 :  0]};
+          EW64: alu_operand_seq = {alu_operand[511:448],
+                                   alu_operand[447:384],
+                                   alu_operand[383:320],
+                                   alu_operand[319:256],
+                                   alu_operand[255:192],
+                                   alu_operand[191:128],
+                                   alu_operand[127: 64],
+                                   alu_operand[63 :  0]};
+        endcase
+      end
+      16 : always_comb begin case (vsew)
+          EW8 : alu_operand_seq = {alu_operand[1023:1016], alu_operand[959:952], alu_operand[895:888], alu_operand[831:824], alu_operand[767:760], alu_operand[703:696], alu_operand[639:632], alu_operand[575:568],
+                                   alu_operand[511 : 504], alu_operand[447:440], alu_operand[383:376], alu_operand[319:312], alu_operand[255:248], alu_operand[191:184], alu_operand[127:120], alu_operand[63 : 56],
+                                   alu_operand[991 : 984], alu_operand[927:920], alu_operand[863:856], alu_operand[799:792], alu_operand[735:728], alu_operand[671:664], alu_operand[607:600], alu_operand[543:536],
+                                   alu_operand[479 : 472], alu_operand[415:408], alu_operand[351:344], alu_operand[287:280], alu_operand[223:216], alu_operand[159:152], alu_operand[95 : 88], alu_operand[31 : 24],
+                                   alu_operand[1007:1000], alu_operand[943:936], alu_operand[879:872], alu_operand[815:808], alu_operand[751:744], alu_operand[687:680], alu_operand[623:616], alu_operand[559:552],
+                                   alu_operand[495 : 488], alu_operand[431:424], alu_operand[367:360], alu_operand[303:296], alu_operand[239:232], alu_operand[175:168], alu_operand[111:104], alu_operand[47 : 40],
+                                   alu_operand[975 : 968], alu_operand[911:904], alu_operand[847:840], alu_operand[783:776], alu_operand[719:712], alu_operand[655:648], alu_operand[591:584], alu_operand[527:520],
+                                   alu_operand[463 : 456], alu_operand[399:392], alu_operand[335:328], alu_operand[271:264], alu_operand[207:200], alu_operand[143:136], alu_operand[79 : 72], alu_operand[15 :  8],
+                                   alu_operand[1015:1008], alu_operand[951:944], alu_operand[887:880], alu_operand[823:816], alu_operand[759:752], alu_operand[695:688], alu_operand[631:624], alu_operand[567:560],
+                                   alu_operand[503 : 496], alu_operand[439:432], alu_operand[375:368], alu_operand[311:304], alu_operand[247:240], alu_operand[183:176], alu_operand[119:112], alu_operand[55 : 48],
+                                   alu_operand[983 : 976], alu_operand[919:912], alu_operand[855:848], alu_operand[791:784], alu_operand[727:720], alu_operand[663:656], alu_operand[599:592], alu_operand[535:528],
+                                   alu_operand[471 : 464], alu_operand[407:400], alu_operand[343:336], alu_operand[279:272], alu_operand[215:208], alu_operand[151:144], alu_operand[87 : 80], alu_operand[23 : 16],
+                                   alu_operand[999 : 992], alu_operand[935:928], alu_operand[871:864], alu_operand[807:800], alu_operand[743:736], alu_operand[679:672], alu_operand[615:608], alu_operand[551:544],
+                                   alu_operand[487 : 480], alu_operand[423:416], alu_operand[359:352], alu_operand[295:288], alu_operand[231:224], alu_operand[167:160], alu_operand[103: 96], alu_operand[39 : 32],
+                                   alu_operand[967 : 960], alu_operand[903:896], alu_operand[839:832], alu_operand[775:768], alu_operand[711:704], alu_operand[647:640], alu_operand[583:576], alu_operand[519:512],
+                                   alu_operand[455 : 448], alu_operand[391:384], alu_operand[327:320], alu_operand[263:256], alu_operand[199:192], alu_operand[135:128], alu_operand[71 : 64], alu_operand[7  :  0]};
+          EW16: alu_operand_seq = {alu_operand[1023:1008], alu_operand[959:944], alu_operand[895:880], alu_operand[831:816],
+                                   alu_operand[767 : 752], alu_operand[703:688], alu_operand[639:624], alu_operand[575:560],
+                                   alu_operand[511 : 496], alu_operand[447:432], alu_operand[383:368], alu_operand[319:304],
+                                   alu_operand[255 : 240], alu_operand[191:176], alu_operand[127:112], alu_operand[63 : 48],
+                                   alu_operand[991 : 976], alu_operand[927:912], alu_operand[863:848], alu_operand[799:784],
+                                   alu_operand[735 : 720], alu_operand[671:656], alu_operand[607:592], alu_operand[543:528],
+                                   alu_operand[479 : 464], alu_operand[415:400], alu_operand[351:336], alu_operand[287:272],
+                                   alu_operand[223 : 208], alu_operand[159:144], alu_operand[95 : 80], alu_operand[31 : 16],
+                                   alu_operand[1007: 992], alu_operand[943:928], alu_operand[879:864], alu_operand[815:800],
+                                   alu_operand[751 : 736], alu_operand[687:672], alu_operand[623:608], alu_operand[559:544],
+                                   alu_operand[495 : 480], alu_operand[431:416], alu_operand[367:352], alu_operand[303:288],
+                                   alu_operand[239 : 224], alu_operand[175:160], alu_operand[111: 96], alu_operand[47 : 32],
+                                   alu_operand[975 : 960], alu_operand[911:896], alu_operand[847:832], alu_operand[783:768],
+                                   alu_operand[719 : 704], alu_operand[655:640], alu_operand[591:576], alu_operand[527:512],
+                                   alu_operand[463 : 448], alu_operand[399:384], alu_operand[335:320], alu_operand[271:256],
+                                   alu_operand[207 : 192], alu_operand[143:128], alu_operand[79 : 64], alu_operand[15 :  0]};
+          EW32: alu_operand_seq = {alu_operand[1023: 992], alu_operand[959:928],
+                                   alu_operand[895 : 864], alu_operand[831:800],
+                                   alu_operand[767 : 736], alu_operand[703:672],
+                                   alu_operand[639 : 608], alu_operand[575:544],
+                                   alu_operand[511 : 480], alu_operand[447:416],
+                                   alu_operand[383 : 352], alu_operand[319:288],
+                                   alu_operand[255 : 224], alu_operand[191:160],
+                                   alu_operand[127 :  96], alu_operand[63 : 32],
+                                   alu_operand[991 : 960], alu_operand[927:896],
+                                   alu_operand[863 : 832], alu_operand[799:768],
+                                   alu_operand[735 : 704], alu_operand[671:640],
+                                   alu_operand[607 : 576], alu_operand[543:512],
+                                   alu_operand[479 : 448], alu_operand[415:384],
+                                   alu_operand[351 : 320], alu_operand[287:256],
+                                   alu_operand[223 : 192], alu_operand[159:128],
+                                   alu_operand[95  :  64], alu_operand[31 :  0]};
+          EW64: alu_operand_seq = {alu_operand[1023: 960],
+                                   alu_operand[959 : 896],
+                                   alu_operand[895 : 832],
+                                   alu_operand[831 : 768],
+                                   alu_operand[767 : 704],
+                                   alu_operand[703 : 640],
+                                   alu_operand[639 : 576],
+                                   alu_operand[575 : 512],
+                                   alu_operand[511 : 448],
+                                   alu_operand[447 : 384],
+                                   alu_operand[383 : 320],
+                                   alu_operand[319 : 256],
+                                   alu_operand[255 : 192],
+                                   alu_operand[191 : 128],
+                                   alu_operand[127 :  64],
+                                   alu_operand[63  :   0]};
+        endcase
+      end
+    endcase
+  endgenerate
+
+endmodule : op_seq

--- a/hardware/src/masku/seq_modules/res_seq.sv
+++ b/hardware/src/masku/seq_modules/res_seq.sv
@@ -1,0 +1,158 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Muhammad Ijaz
+// Description:
+// This is Ara's operand sequencer module, which is responsible for sequencing the operand recieved from lane_sequencer
+
+
+module res_seq import ara_pkg::*; import rvv_pkg::*; #(
+    parameter  int  unsigned NrLanes = 0,
+    // Dependant parameters. DO NOT CHANGE!
+    localparam int  unsigned DataWidth = $bits(elen_t) // Width of the lane datapath
+  ) (
+    // Interface with the masku
+    input  logic [3:0]                                 vsew,
+    input  logic [NrLanes*DataWidth-1:0]               alu_result,
+    output logic [NrLanes*DataWidth-1:0]               alu_result_seq
+  );
+
+  generate
+    case (NrLanes)
+      2 : always_comb begin case (vsew)
+          EW8 : alu_result_seq = {alu_result[127:120], alu_result[63:56], alu_result[95:88], alu_result[31:24], alu_result[111:104], alu_result[47:40] ,alu_result[79:72], alu_result[15:8],
+                                        alu_result[119:112], alu_result[55:48], alu_result[87:80], alu_result[23:16], alu_result[103: 96], alu_result[39:32], alu_result[71:64], alu_result[7 :0]};
+          EW16: alu_result_seq = {alu_result[127:112], alu_result[63:48], alu_result[95:80], alu_result[31:16],
+                                        alu_result[111: 96], alu_result[47:32], alu_result[79:64], alu_result[15: 0]};
+          EW32: alu_result_seq = {alu_result[127: 96], alu_result[63:32],
+                                        alu_result[95 : 64], alu_result[31: 0]};
+          EW64: alu_result_seq = {alu_result[127: 64],
+                                        alu_result[63 :  0]};
+        endcase
+      end
+      4 : always_comb begin case (vsew)
+          EW8 : alu_result_seq = {alu_result[255:248], alu_result[191:184], alu_result[127:120], alu_result[63:56], alu_result[223:216], alu_result[159:152], alu_result[95:88], alu_result[31:24],
+                                        alu_result[247:240], alu_result[183:176], alu_result[119:112], alu_result[55:48], alu_result[215:208], alu_result[151:144] ,alu_result[87:80], alu_result[23:16],
+                                        alu_result[239:232], alu_result[175:168], alu_result[111:104], alu_result[47:40], alu_result[207:200], alu_result[143:136], alu_result[79:72], alu_result[15: 8],
+                                        alu_result[231:224], alu_result[167:160], alu_result[103: 96], alu_result[39:32], alu_result[199:192], alu_result[135:128], alu_result[71:64], alu_result[7 : 0]};
+          EW16: alu_result_seq = {alu_result[255:240], alu_result[191:176], alu_result[127:112], alu_result[63:48],
+                                        alu_result[223:208], alu_result[159:144], alu_result[95 : 80], alu_result[31:16],
+                                        alu_result[239:224], alu_result[175:160], alu_result[111: 96], alu_result[47:32],
+                                        alu_result[207:192], alu_result[143:128], alu_result[79 : 64], alu_result[15: 0]};
+          EW32: alu_result_seq = {alu_result[255:224], alu_result[191:160],
+                                        alu_result[127: 96], alu_result[63 : 32],
+                                        alu_result[223:192], alu_result[159:128],
+                                        alu_result[95 : 64], alu_result[31 :  0]};
+          EW64: alu_result_seq = {alu_result[255:192],
+                                        alu_result[191:128],
+                                        alu_result[127: 64],
+                                        alu_result[63 :  0]};
+        endcase
+      end
+      8 : always_comb begin case (vsew)
+          EW8 : alu_result_seq = {alu_result[511:504], alu_result[447:440], alu_result[383:376], alu_result[319:312], alu_result[255:248], alu_result[191:184], alu_result[127:120], alu_result[63:56],
+                                        alu_result[503:496], alu_result[439:432], alu_result[375:368], alu_result[311:304], alu_result[247:240], alu_result[183:176], alu_result[119:112], alu_result[55:48],
+                                        alu_result[495:488], alu_result[431:424], alu_result[367:360], alu_result[303:296], alu_result[239:232], alu_result[175:168], alu_result[111:104], alu_result[47:40],
+                                        alu_result[487:480], alu_result[423:416], alu_result[359:352], alu_result[295:288], alu_result[231:224], alu_result[167:160], alu_result[103: 96], alu_result[39:32],
+                                        alu_result[479:472], alu_result[415:408], alu_result[351:344], alu_result[287:280], alu_result[223:216], alu_result[159:152], alu_result[95 : 88], alu_result[31:24],
+                                        alu_result[471:464], alu_result[407:400], alu_result[343:336], alu_result[279:272], alu_result[215:208], alu_result[151:144], alu_result[87 : 80], alu_result[23:16],
+                                        alu_result[463:456], alu_result[399:392], alu_result[335:328], alu_result[271:264], alu_result[207:200], alu_result[143:136], alu_result[79 : 72], alu_result[15: 8],
+                                        alu_result[455:448], alu_result[391:384], alu_result[327:320], alu_result[263:256], alu_result[199:192], alu_result[135:128], alu_result[71 : 64], alu_result[7 : 0]};
+          EW16: alu_result_seq = {alu_result[511:496], alu_result[447:432], alu_result[383:368], alu_result[319:304],
+                                        alu_result[255:240], alu_result[191:176], alu_result[127:112], alu_result[63 : 48],
+                                        alu_result[479:464], alu_result[415:400], alu_result[351:336], alu_result[287:272],
+                                        alu_result[223:208], alu_result[159:144], alu_result[95 : 80], alu_result[31 : 16],
+                                        alu_result[495:480], alu_result[431:416], alu_result[367:352], alu_result[303:288],
+                                        alu_result[239:224], alu_result[175:160], alu_result[111: 96], alu_result[47 : 32],
+                                        alu_result[463:448], alu_result[399:384], alu_result[335:320], alu_result[271:256],
+                                        alu_result[207:192], alu_result[143:128], alu_result[79 : 64], alu_result[15 :  0]};
+          EW32: alu_result_seq = {alu_result[511:480], alu_result[447:416],
+                                        alu_result[383:352], alu_result[319:288],
+                                        alu_result[255:224], alu_result[191:160],
+                                        alu_result[127: 96], alu_result[63 : 32],
+                                        alu_result[479:448], alu_result[415:384],
+                                        alu_result[351:320], alu_result[287:256],
+                                        alu_result[223:192], alu_result[159:128],
+                                        alu_result[95 : 64], alu_result[31 :  0]};
+          EW64: alu_result_seq = {alu_result[511:448],
+                                        alu_result[447:384],
+                                        alu_result[383:320],
+                                        alu_result[319:256],
+                                        alu_result[255:192],
+                                        alu_result[191:128],
+                                        alu_result[127: 64],
+                                        alu_result[63 :  0]};
+        endcase
+      end
+      16 : always_comb begin case (vsew)
+          EW8 : alu_result_seq = {alu_result[1023:1016], alu_result[959:952], alu_result[895:888], alu_result[831:824], alu_result[767:760], alu_result[703:696], alu_result[639:632], alu_result[575:568],
+                                        alu_result[1015:1008], alu_result[951:944], alu_result[887:880], alu_result[823:816], alu_result[759:752], alu_result[695:688], alu_result[631:624], alu_result[567:560],
+                                        alu_result[1007:1000], alu_result[943:936], alu_result[879:872], alu_result[815:808], alu_result[751:744], alu_result[687:680], alu_result[623:616], alu_result[559:552],
+                                        alu_result[999 : 992], alu_result[935:928], alu_result[871:864], alu_result[807:800], alu_result[743:736], alu_result[679:672], alu_result[615:608], alu_result[551:544],
+                                        alu_result[991 : 984], alu_result[927:920], alu_result[863:856], alu_result[799:792], alu_result[735:728], alu_result[671:664], alu_result[607:600], alu_result[543:536],
+                                        alu_result[983 : 976], alu_result[919:912], alu_result[855:848], alu_result[791:784], alu_result[727:720], alu_result[663:656], alu_result[599:592], alu_result[535:528],
+                                        alu_result[975 : 968], alu_result[911:904], alu_result[847:840], alu_result[783:776], alu_result[719:712], alu_result[655:648], alu_result[591:584], alu_result[527:520],
+                                        alu_result[967 : 960], alu_result[903:896], alu_result[839:832], alu_result[775:768], alu_result[711:704], alu_result[647:640], alu_result[583:576], alu_result[519:512],
+                                        alu_result[511 : 504], alu_result[447:440], alu_result[383:376], alu_result[319:312], alu_result[255:248], alu_result[191:184], alu_result[127:120], alu_result[63 : 56],
+                                        alu_result[503 : 496], alu_result[439:432], alu_result[375:368], alu_result[311:304], alu_result[247:240], alu_result[183:176], alu_result[119:112], alu_result[55 : 48],
+                                        alu_result[495 : 488], alu_result[431:424], alu_result[367:360], alu_result[303:296], alu_result[239:232], alu_result[175:168], alu_result[111:104], alu_result[47 : 40],
+                                        alu_result[487 : 480], alu_result[423:416], alu_result[359:352], alu_result[295:288], alu_result[231:224], alu_result[167:160], alu_result[103: 96], alu_result[39 : 32],
+                                        alu_result[479 : 472], alu_result[415:408], alu_result[351:344], alu_result[287:280], alu_result[223:216], alu_result[159:152], alu_result[95 : 88], alu_result[31 : 24],
+                                        alu_result[471 : 464], alu_result[407:400], alu_result[343:336], alu_result[279:272], alu_result[215:208], alu_result[151:144], alu_result[87 : 80], alu_result[23 : 16],
+                                        alu_result[463 : 456], alu_result[399:392], alu_result[335:328], alu_result[271:264], alu_result[207:200], alu_result[143:136], alu_result[79 : 72], alu_result[15 :  8],
+                                        alu_result[455 : 448], alu_result[391:384], alu_result[327:320], alu_result[263:256], alu_result[199:192], alu_result[135:128], alu_result[71 : 64], alu_result[7  :  0]};
+          EW16: alu_result_seq = {alu_result[1023:1008], alu_result[959:944], alu_result[895:880], alu_result[831:816],
+                                        alu_result[767 : 752], alu_result[703:688], alu_result[639:624], alu_result[575:560],
+                                        alu_result[511 : 496], alu_result[447:432], alu_result[383:368], alu_result[319:304],
+                                        alu_result[255 : 240], alu_result[191:176], alu_result[127:112], alu_result[63 : 48],
+                                        alu_result[991 : 976], alu_result[927:912], alu_result[863:848], alu_result[799:784],
+                                        alu_result[735 : 720], alu_result[671:656], alu_result[607:592], alu_result[543:528],
+                                        alu_result[479 : 464], alu_result[415:400], alu_result[351:336], alu_result[287:272],
+                                        alu_result[223 : 208], alu_result[159:144], alu_result[95 : 80], alu_result[31 : 16],
+                                        alu_result[1007: 992], alu_result[943:928], alu_result[879:864], alu_result[815:800],
+                                        alu_result[751 : 736], alu_result[687:672], alu_result[623:608], alu_result[559:544],
+                                        alu_result[495 : 480], alu_result[431:416], alu_result[367:352], alu_result[303:288],
+                                        alu_result[239 : 224], alu_result[175:160], alu_result[111: 96], alu_result[47 : 32],
+                                        alu_result[975 : 960], alu_result[911:896], alu_result[847:832], alu_result[783:768],
+                                        alu_result[719 : 704], alu_result[655:640], alu_result[591:576], alu_result[527:512],
+                                        alu_result[463 : 448], alu_result[399:384], alu_result[335:320], alu_result[271:256],
+                                        alu_result[207 : 192], alu_result[143:128], alu_result[79 : 64], alu_result[15 :  0]};
+          EW32: alu_result_seq = {alu_result[1023: 992], alu_result[959:928],
+                                        alu_result[895 : 864], alu_result[831:800],
+                                        alu_result[767 : 736], alu_result[703:672],
+                                        alu_result[639 : 608], alu_result[575:544],
+                                        alu_result[511 : 480], alu_result[447:416],
+                                        alu_result[383 : 352], alu_result[319:288],
+                                        alu_result[255 : 224], alu_result[191:160],
+                                        alu_result[127 :  96], alu_result[63 : 32],
+                                        alu_result[991 : 960], alu_result[927:896],
+                                        alu_result[863 : 832], alu_result[799:768],
+                                        alu_result[735 : 704], alu_result[671:640],
+                                        alu_result[607 : 576], alu_result[543:512],
+                                        alu_result[479 : 448], alu_result[415:384],
+                                        alu_result[351 : 320], alu_result[287:256],
+                                        alu_result[223 : 192], alu_result[159:128],
+                                        alu_result[95  :  64], alu_result[31 :  0]};
+          EW64: alu_result_seq = {alu_result[1023: 960],
+                                        alu_result[959 : 896],
+                                        alu_result[895 : 832],
+                                        alu_result[831 : 768],
+                                        alu_result[767 : 704],
+                                        alu_result[703 : 640],
+                                        alu_result[639 : 576],
+                                        alu_result[575 : 512],
+                                        alu_result[511 : 448],
+                                        alu_result[447 : 384],
+                                        alu_result[383 : 320],
+                                        alu_result[319 : 256],
+                                        alu_result[255 : 192],
+                                        alu_result[191 : 128],
+                                        alu_result[127 :  64],
+                                        alu_result[63  :   0]};
+        endcase
+      end
+    endcase
+  endgenerate
+
+endmodule : res_seq


### PR DESCRIPTION
Add support for vmsbf, vmsof, vmsif, viota, vid, vrgather, vrgatherei16 and vcompress instructions

## Changelog

### Fixed

- N/A

### Added

- Added support for vmsbf, vmsof, vmsif, viota, vid, vrgather, vrgatherei16 and vcompress instructions and added their updated tests

### Changed

- N/A

## Checklist

- [ ] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
